### PR TITLE
Wrap time-intensive loops from storm mode classification in jit decorators to increase speed

### DIFF
--- a/monte_python/_mode_classifier.py
+++ b/monte_python/_mode_classifier.py
@@ -9,7 +9,6 @@ from .object_identification import label
 from .object_quality_control import QualityControler, whereeq
 from numba.core.errors import NumbaDeprecationWarning, NumbaPendingDeprecationWarning
 import warnings
-from time import time
 
 warnings.simplefilter('ignore', category=NumbaDeprecationWarning)
 warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)
@@ -17,799 +16,799 @@ warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)
 #ANALYSIS_DX = 3000
 
 def get_constituent_storms(
-	model,
-	min_thresh,
-	dbzcomp_qc_params, 
-	storm_types,
-	dbzcomp_labels,
-	dbzcomp_props,
-	dbzcomp_values,
-	uh_labels,
-	uh_props,
-	uh_values,
-	itr,
-	max_itr,
-	ANALYSIS_DX, 
-	debug=False,
+    model,
+    min_thresh,
+    dbzcomp_qc_params, 
+    storm_types,
+    dbzcomp_labels,
+    dbzcomp_props,
+    dbzcomp_values,
+    uh_labels,
+    uh_props,
+    uh_values,
+    itr,
+    max_itr,
+    ANALYSIS_DX, 
+    debug=False,
 ):
-	new_storm_types = storm_types.copy()
-	new_dbzcomp_labels = dbzcomp_labels.copy()
-	new_dbzcomp_props = dbzcomp_props.copy()
-
-	label_inc = 100 * (itr - 1)
-	
-	t1 = time()
-	temp_dbzcomp_labels, temp_dbzcomp_props = label(
-		input_data=dbzcomp_values,
-		method="single_threshold",
-		params={"bdry_thresh": min_thresh},
-	)
-	
-	if len(temp_dbzcomp_props) > 0:
-		# Apply quality control
-		t1 = time()
-		temp_dbzcomp_labels, temp_dbzcomp_props = QualityControler().quality_control(
-			object_labels=temp_dbzcomp_labels,
-			object_properties=temp_dbzcomp_props,
-			input_data=dbzcomp_values,
-			qc_params=dbzcomp_qc_params,
-		)
-
-	# Identify candidate embedded storm objects
-	t1 = time()
-	temp_storm_types, labels_with_matched_rotation = get_storm_types(
-		model,
-		temp_dbzcomp_labels,
-		temp_dbzcomp_props,
-		dbzcomp_values,
-		uh_labels,
-		uh_props,
-		uh_values,
-		ANALYSIS_DX, 
-		itr == max_itr,
-	)
-	
-	dbz_coords = [prop.coords for prop in dbzcomp_props]
-	if (len(temp_storm_types)):
-		new_storm_types,new_dbzcomp_labels,n_append = iterate_storm_types(
-						storm_types, new_storm_types,new_dbzcomp_labels,
-						dbz_coords, 
-						[prop.centroid for prop in dbzcomp_props],
-						[prop.equivalent_diameter for prop in dbzcomp_props], 
-						[prop.area for prop in dbzcomp_props],
-						temp_storm_types, 
-						[prop.coords for prop in temp_dbzcomp_props], 
-						[prop.label for prop in temp_dbzcomp_props],
-						temp_dbzcomp_labels,
-						[prop.centroid for prop in temp_dbzcomp_props], 
-						[prop.equivalent_diameter for prop in temp_dbzcomp_props],
-						[prop.area for prop in temp_dbzcomp_props],
-						label_inc
-						)
-						
-		for n in n_append:
-			new_dbzcomp_props.append(temp_dbzcomp_props[n])
-
-	# After last iteration, do final QC
-
-	if itr == max_itr:
-
-		# Create "family tree" of objects; new_storm_depths contains the "generation" of each object; 
-		# new_storm_parent_labels contains the parent label for each child object; new_storm_embs 
-		# contains the parent type of each child object
-		# new_storm_depths is later used to process objects in order of their generation
-
-		new_storm_parent_labels, new_storm_embs, new_storm_depths = object_hierarchy(
-			new_storm_types, new_dbzcomp_props
-		)
-
-		new_storm_types2 = new_storm_types.copy()
-		new_storm_embs2 = new_storm_embs.copy()
-		new_dbzcomp_props2 = new_dbzcomp_props.copy()
-		new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
-		new_storm_parent_labels2 = new_storm_parent_labels.copy()
-		new_storm_depths2 = new_storm_depths.copy()
-
-	else:
-
-		new_storm_embs = ["NONEMB" for x in new_storm_types]
-
-	if itr == max_itr:
-
-		remove_indices = []
-		parent_labels = []
-
-		for n, storm_type in enumerate(new_storm_types):
-
-			if new_storm_embs[n] in ["EMB-QLCS"]:
-
-				"""parent_label = new_dbzcomp_props[n].label
-
-				for nn in range(len(new_storm_types)):
-				  if nn != n and new_storm_parent_labels[nn] == parent_label:
-					if nn not in remove_indices:
-					  remove_indices.append(nn)
-					  print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
-
-				parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-				for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-					if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
-
-						child_coords = np.asarray(storm2_region.coords)
-
-						if check_overlap(child_coords, parent_coords):
+    new_storm_types = storm_types.copy()
+    new_dbzcomp_labels = dbzcomp_labels.copy()
+    new_dbzcomp_props = dbzcomp_props.copy()
+
+    label_inc = 100 * (itr - 1)
+    
+    t1 = time()
+    temp_dbzcomp_labels, temp_dbzcomp_props = label(
+        input_data=dbzcomp_values,
+        method="single_threshold",
+        params={"bdry_thresh": min_thresh},
+    )
+    
+    if len(temp_dbzcomp_props) > 0:
+        # Apply quality control
+        t1 = time()
+        temp_dbzcomp_labels, temp_dbzcomp_props = QualityControler().quality_control(
+            object_labels=temp_dbzcomp_labels,
+            object_properties=temp_dbzcomp_props,
+            input_data=dbzcomp_values,
+            qc_params=dbzcomp_qc_params,
+        )
+
+    # Identify candidate embedded storm objects
+    t1 = time()
+    temp_storm_types, labels_with_matched_rotation = get_storm_types(
+        model,
+        temp_dbzcomp_labels,
+        temp_dbzcomp_props,
+        dbzcomp_values,
+        uh_labels,
+        uh_props,
+        uh_values,
+        ANALYSIS_DX, 
+        itr == max_itr,
+    )
+    
+    dbz_coords = [prop.coords for prop in dbzcomp_props]
+    if (len(temp_storm_types)):
+        new_storm_types,new_dbzcomp_labels,n_append = iterate_storm_types(
+                        storm_types, new_storm_types,new_dbzcomp_labels,
+                        dbz_coords, 
+                        [prop.centroid for prop in dbzcomp_props],
+                        [prop.equivalent_diameter for prop in dbzcomp_props], 
+                        [prop.area for prop in dbzcomp_props],
+                        temp_storm_types, 
+                        [prop.coords for prop in temp_dbzcomp_props], 
+                        [prop.label for prop in temp_dbzcomp_props],
+                        temp_dbzcomp_labels,
+                        [prop.centroid for prop in temp_dbzcomp_props], 
+                        [prop.equivalent_diameter for prop in temp_dbzcomp_props],
+                        [prop.area for prop in temp_dbzcomp_props],
+                        label_inc
+                        )
+                        
+        for n in n_append:
+            new_dbzcomp_props.append(temp_dbzcomp_props[n])
+
+    # After last iteration, do final QC
+
+    if itr == max_itr:
+
+        # Create "family tree" of objects; new_storm_depths contains the "generation" of each object; 
+        # new_storm_parent_labels contains the parent label for each child object; new_storm_embs 
+        # contains the parent type of each child object
+        # new_storm_depths is later used to process objects in order of their generation
+
+        new_storm_parent_labels, new_storm_embs, new_storm_depths = object_hierarchy(
+            new_storm_types, new_dbzcomp_props
+        )
+
+        new_storm_types2 = new_storm_types.copy()
+        new_storm_embs2 = new_storm_embs.copy()
+        new_dbzcomp_props2 = new_dbzcomp_props.copy()
+        new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
+        new_storm_parent_labels2 = new_storm_parent_labels.copy()
+        new_storm_depths2 = new_storm_depths.copy()
+
+    else:
+
+        new_storm_embs = ["NONEMB" for x in new_storm_types]
+
+    if itr == max_itr:
+
+        remove_indices = []
+        parent_labels = []
+
+        for n, storm_type in enumerate(new_storm_types):
+
+            if new_storm_embs[n] in ["EMB-QLCS"]:
+
+                """parent_label = new_dbzcomp_props[n].label
+
+                for nn in range(len(new_storm_types)):
+                  if nn != n and new_storm_parent_labels[nn] == parent_label:
+                    if nn not in remove_indices:
+                      remove_indices.append(nn)
+                      print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
+
+                parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+
+                for nn, storm2_region in enumerate(new_dbzcomp_props):
+
+                    if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
+
+                        child_coords = np.asarray(storm2_region.coords)
+
+                        if check_overlap(child_coords, parent_coords):
 
-							if nn not in remove_indices:
-								remove_indices.append(nn)
-								parent_labels.append(new_storm_parent_labels[nn])
-								if debug:
-									print(
-										"Removing %s within %s within %s"
-										% (
-											new_storm_types[nn],
-											storm_type,
-											new_storm_embs[n][4:],
-										)
-									)
+                            if nn not in remove_indices:
+                                remove_indices.append(nn)
+                                parent_labels.append(new_storm_parent_labels[nn])
+                                if debug:
+                                    print(
+                                        "Removing %s within %s within %s"
+                                        % (
+                                            new_storm_types[nn],
+                                            storm_type,
+                                            new_storm_embs[n][4:],
+                                        )
+                                    )
 
-		for ind in sorted(remove_indices, reverse=True):
-			new_storm_types2.pop(ind)
-			new_storm_embs2.pop(ind)
-			new_dbzcomp_props2.pop(ind)
-			new_storm_parent_labels2.pop(ind)
+        for ind in sorted(remove_indices, reverse=True):
+            new_storm_types2.pop(ind)
+            new_storm_embs2.pop(ind)
+            new_dbzcomp_props2.pop(ind)
+            new_storm_parent_labels2.pop(ind)
 
-		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-			new_storm_types2, new_dbzcomp_props2
-		)
+        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+            new_storm_types2, new_dbzcomp_props2
+        )
 
-		new_storm_types = new_storm_types2.copy()
-		new_storm_embs = new_storm_embs2.copy()
-		new_dbzcomp_props = new_dbzcomp_props2.copy()
-		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-		new_storm_parent_labels = new_storm_parent_labels2.copy()
-		new_storm_depths = new_storm_depths2.copy()
+        new_storm_types = new_storm_types2.copy()
+        new_storm_embs = new_storm_embs2.copy()
+        new_dbzcomp_props = new_dbzcomp_props2.copy()
+        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+        new_storm_parent_labels = new_storm_parent_labels2.copy()
+        new_storm_depths = new_storm_depths2.copy()
 
-	if itr == max_itr:
+    if itr == max_itr:
 
-		# Reclassify QLCS as cluster if object area dominated by CELLs
+        # Reclassify QLCS as cluster if object area dominated by CELLs
 
-		for n, storm_type in enumerate(new_storm_types):
+        for n, storm_type in enumerate(new_storm_types):
 
-			if (
-				new_storm_types[n] == "QLCS"
-				and new_dbzcomp_props[n].major_axis_length < 150 / 3.0
-			):
+            if (
+                new_storm_types[n] == "QLCS"
+                and new_dbzcomp_props[n].major_axis_length < 150 / 3.0
+            ):
 
-				num_const = 0
-				num_rot = 0
-				const_area = 0
-
-				for nn in range(len(new_storm_types)):
-
-					if (
-						nn != n
-						and new_storm_parent_labels[nn] == new_dbzcomp_props[n].label
-					):
+                num_const = 0
+                num_rot = 0
+                const_area = 0
+
+                for nn in range(len(new_storm_types)):
+
+                    if (
+                        nn != n
+                        and new_storm_parent_labels[nn] == new_dbzcomp_props[n].label
+                    ):
 
-						num_const += 1
-						if new_storm_types[nn] == "ROTATE":
-							num_rot += 1
-						const_area += new_dbzcomp_props[nn].area
+                        num_const += 1
+                        if new_storm_types[nn] == "ROTATE":
+                            num_rot += 1
+                        const_area += new_dbzcomp_props[nn].area
 
-				const_area_frac = const_area / float(new_dbzcomp_props[n].area)
+                const_area_frac = const_area / float(new_dbzcomp_props[n].area)
 
-				if const_area_frac > 0.75:
-
-					if num_rot > 1:
-						new_storm_types2[n] = "SUP_CLUST"
-					elif num_const > 1:
-						new_storm_types2[n] = "CLUSTER"
-					else:
-						new_storm_types2[n] = "AMORPHOUS"
-					if debug:
-						print(
-							"CONVERTING QLCS to %s since const_area_frac = %.2f"
-							% (new_storm_types2[n], const_area_frac)
-						)
+                if const_area_frac > 0.75:
+
+                    if num_rot > 1:
+                        new_storm_types2[n] = "SUP_CLUST"
+                    elif num_const > 1:
+                        new_storm_types2[n] = "CLUSTER"
+                    else:
+                        new_storm_types2[n] = "AMORPHOUS"
+                    if debug:
+                        print(
+                            "CONVERTING QLCS to %s since const_area_frac = %.2f"
+                            % (new_storm_types2[n], const_area_frac)
+                        )
 
-				else:
+                else:
 
-					if debug:
-						print(
-							"RETAINING QLCS since const_area_frac = %.2f"
-							% const_area_frac
-						)
+                    if debug:
+                        print(
+                            "RETAINING QLCS since const_area_frac = %.2f"
+                            % const_area_frac
+                        )
 
-		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-			new_storm_types2, new_dbzcomp_props2
-		)
+        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+            new_storm_types2, new_dbzcomp_props2
+        )
 
-		new_storm_types = new_storm_types2.copy()
-		new_storm_embs = new_storm_embs2.copy()
-		new_dbzcomp_props = new_dbzcomp_props2.copy()
-		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-		new_storm_parent_labels = new_storm_parent_labels2.copy()
-		new_storm_depths = new_storm_depths2.copy()
+        new_storm_types = new_storm_types2.copy()
+        new_storm_embs = new_storm_embs2.copy()
+        new_dbzcomp_props = new_dbzcomp_props2.copy()
+        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+        new_storm_parent_labels = new_storm_parent_labels2.copy()
+        new_storm_depths = new_storm_depths2.copy()
 
-	if itr == max_itr + 999:
+    if itr == max_itr + 999:
 
-		remove_indices = []
+        remove_indices = []
 
-		for n, storm_type in enumerate(new_storm_types):
+        for n, storm_type in enumerate(new_storm_types):
 
-			if new_storm_embs[n] in ["EMB-QLCS"]:
+            if new_storm_embs[n] in ["EMB-QLCS"]:
 
-				"""parent_label = new_dbzcomp_props[n].label
+                """parent_label = new_dbzcomp_props[n].label
 
-				for nn in range(len(new_storm_types)):
-				  if nn != n and new_storm_parent_labels[nn] == parent_label:
-					if nn not in remove_indices:
-					  remove_indices.append(nn)
-					  print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
+                for nn in range(len(new_storm_types)):
+                  if nn != n and new_storm_parent_labels[nn] == parent_label:
+                    if nn not in remove_indices:
+                      remove_indices.append(nn)
+                      print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
 
-				parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+                parent_coords = np.asarray(new_dbzcomp_props[n].coords)
 
-				for nn, storm2_region in enumerate(new_dbzcomp_props):
+                for nn, storm2_region in enumerate(new_dbzcomp_props):
 
-					if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
+                    if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
 
-						child_coords = np.asarray(storm2_region.coords)
+                        child_coords = np.asarray(storm2_region.coords)
 
-						if check_overlap(child_coords, parent_coords):
+                        if check_overlap(child_coords, parent_coords):
 
-							if nn not in remove_indices:
-								remove_indices.append(nn)
-								if debug:
-									print(
-										"Removing %s within %s within %s"
-										% (
-											new_storm_types[nn],
-											storm_type,
-											new_storm_embs[n][4:],
-										)
-									)
+                            if nn not in remove_indices:
+                                remove_indices.append(nn)
+                                if debug:
+                                    print(
+                                        "Removing %s within %s within %s"
+                                        % (
+                                            new_storm_types[nn],
+                                            storm_type,
+                                            new_storm_embs[n][4:],
+                                        )
+                                    )
 
-		for ind in sorted(remove_indices, reverse=True):
-			new_storm_types2.pop(ind)
-			new_storm_embs2.pop(ind)
-			new_dbzcomp_props2.pop(ind)
-			new_storm_parent_labels2.pop(ind)
-
-		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-			new_storm_types2, new_dbzcomp_props2
-		)
-
-		new_storm_types = new_storm_types2.copy()
-		new_storm_embs = new_storm_embs2.copy()
-		new_dbzcomp_props = new_dbzcomp_props2.copy()
-		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-		new_storm_parent_labels = new_storm_parent_labels2.copy()
-		new_storm_depths = new_storm_depths2.copy()
-
-	if itr == max_itr and len(new_storm_depths)>0:
-
-		# If object embedded within QLCS_embedded object, discard the former
-		# If object embedded within AMORPHOUS or CELL is the only object embedded therein, discard it. If parent object is AMORPHOUS, reclassify it as discarded child object type.
-		# If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is unembedded, reclassify parent as CLUSTER or SUP_CLUSTER.
-		# If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is embedded in another object, remove parent since it we don't want embedded clusters
-
-		for depth in range(max(new_storm_depths), -1, -1):
-
-			if debug:
-				print("depth = %d" % depth)
-			remove_indices = []
-			parent_labels = []
-
-			for n, storm_type in enumerate(new_storm_types):
-
-				if new_storm_depths[n] == depth:  # and depth==2:
-
-					if new_storm_embs[n] in ["EMB-QLCS999"]:
-
-						parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-						for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-							if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
-
-								child_coords = np.asarray(storm2_region.coords)
-
-								if check_overlap(child_coords, parent_coords):
-
-									if nn not in remove_indices:
-										remove_indices.append(nn)
-										parent_labels.append(new_dbzcomp_props[n].label)
-										if debug:
-											print(
-												"Removing %s within %s within %s"
-												% (
-													new_storm_types[nn],
-													storm_type,
-													new_storm_embs[n][4:],
-												)
-											)
-
-					elif new_storm_embs[n] in ["EMB-CELL", "EMB-CLUS"]:
-
-						parent_label = new_storm_parent_labels[n]
-						const_indices = [n]
-
-						for nn in range(len(new_storm_types)):
-							if new_dbzcomp_props[nn].label == parent_label:
-								parent_index = nn
-								break
-
-						if new_storm_types[n] == "ROTATE":
-							num_sups = 1
-						else:
-							num_sups = 0
-
-						for nn in range(len(new_storm_types)):
-
-							if nn != n and new_storm_parent_labels[nn] == parent_label:
-
-								const_indices.append(nn)
-								if new_storm_types[nn] == "ROTATE":
-									num_sups += 1
-
-						if len(const_indices) == 1:
-							if n not in remove_indices:
-								remove_indices.append(n)
-								parent_labels.append(parent_label)
-								if new_storm_embs[n] == "EMB-CLUS":
-									new_storm_types2[parent_index] = storm_type
-								if debug:
-									print(
-										"Removing singleton %s from %s (which is now a %s)"
-										% (
-											storm_type,
-											new_storm_types[parent_index],
-											storm_type,
-										)
-									)
-
-						elif new_storm_embs[
-							parent_index
-						] == "NONEMB" and new_storm_types[parent_index] not in [
-							"CLUSTER",
-							"SUP_CLUST",
-						]:
-
-							if num_sups > 1:
-								if debug:
-									print(
-										"Converting parent %s to SUP_CLUST"
-										% new_storm_types2[parent_index]
-									)
-								new_storm_types2[parent_index] = "SUP_CLUST"
-							else:
-								if debug:
-									print(
-										"Converting parent %s to CLUSTER"
-										% new_storm_types2[parent_index]
-									)
-								new_storm_types2[parent_index] = "CLUSTER"
-							for ind in const_indices:
-								new_storm_embs2[ind] = "EMB-CLUS"
-
-						elif new_storm_embs[parent_index] != "NONEMB":
-
-							if parent_index not in remove_indices:
-								if debug:
-									print(
-										"Removing parent %s since it is actually an embedded cluster"
-										% new_storm_types[parent_index]
-									)
-								remove_indices.append(parent_index)
-								parent_labels.append(
-									new_storm_parent_labels[parent_index]
-								)
-								for ind in const_indices:
-									new_storm_embs2[ind] = "EMB-CLUS"
-
-			if len(remove_indices) != len(set(remove_indices)):
-				if debug:
-					print("DUPLICATES in remove_indices!!! Exiting.")
-					sys.exit(1)
-
-			for ind in sorted(remove_indices, reverse=True):
-				new_storm_types2.pop(ind)
-				new_storm_embs2.pop(ind)
-				new_dbzcomp_props2.pop(ind)
-				new_storm_parent_labels2.pop(ind)
-
-			(
-				new_storm_parent_labels2,
-				new_storm_embs2,
-				new_storm_depths2,
-			) = object_hierarchy(new_storm_types2, new_dbzcomp_props2)
-
-			new_storm_types = new_storm_types2.copy()
-			new_storm_embs = new_storm_embs2.copy()
-			new_dbzcomp_props = new_dbzcomp_props2.copy()
-			new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-			new_storm_parent_labels = new_storm_parent_labels2.copy()
-			new_storm_depths = new_storm_depths2.copy()
-
-	if itr == max_itr:
-
-		for n, storm_type in enumerate(new_storm_types):
-
-			if new_storm_types[n] == "CLUSTER":
-
-				num_sup = 0
-				parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-				for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-					if (
-						new_storm_types[nn] == "ROTATE"
-						and new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area
-					):
-
-						child_coords = np.asarray(storm2_region.coords)
-
-						if check_overlap(child_coords, parent_coords):
-
-							num_sup += 1
-
-							if num_sup == 2:
-								new_storm_types[n] = "SUP_CLUST"
-								if debug:
-									print("CONVERTING CLUSTER TO SUP_CLUST!!! Exiting.")
-									sys.exit(1)
-								break
-
-		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-			new_storm_types2, new_dbzcomp_props2
-		)
-
-		new_storm_types = new_storm_types2.copy()
-		new_storm_embs = new_storm_embs2.copy()
-		new_dbzcomp_props = new_dbzcomp_props2.copy()
-		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-		new_storm_parent_labels = new_storm_parent_labels2.copy()
-		new_storm_depths = new_storm_depths2.copy()
-
-	if itr == max_itr:
-
-		# Recast irregular discrete cell objects as AMORPHOUS
-
-		new_storm_types2 = list(new_storm_types)
-		new_storm_embs2 = list(new_storm_embs)
-		new_dbzcomp_props2 = list(new_dbzcomp_props)
-		new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
-
-		for n, storm_type in enumerate(new_storm_types):
-
-			if (
-				storm_type in ["ROTATE", "NONROT"]
-				and new_storm_embs[n] == "NONEMB"
-				and (
-					new_dbzcomp_props[n].major_axis_length > 75 / 3.0
-					or new_dbzcomp_props[n].solidity < 0.7
-					or new_dbzcomp_props[n].eccentricity > 0.97
-				)
-			):
-
-				new_storm_types2[n] = "AMORPHOUS"
-				if debug:
-					print(
-						"Converting DISCRETE CELL to AMORPHOUS",
-						new_dbzcomp_props[n].area,
-						new_dbzcomp_props[n].major_axis_length,
-						new_dbzcomp_props[n].eccentricity,
-						new_dbzcomp_props[n].solidity,
-					)
-
-		new_storm_types = new_storm_types2
-		new_storm_embs = new_storm_embs2
-		new_dbzcomp_props = new_dbzcomp_props2
-		new_dbzcomp_labels = new_dbzcomp_labels2
-
-	if itr == max_itr:
-		return new_storm_types, new_storm_embs, new_dbzcomp_props, new_storm_depths2
-	else:
-		return new_storm_types, new_storm_embs, new_dbzcomp_props, None
-
-	return new_storm_types, new_storm_embs, new_dbzcomp_labels, new_dbzcomp_props
+        for ind in sorted(remove_indices, reverse=True):
+            new_storm_types2.pop(ind)
+            new_storm_embs2.pop(ind)
+            new_dbzcomp_props2.pop(ind)
+            new_storm_parent_labels2.pop(ind)
+
+        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+            new_storm_types2, new_dbzcomp_props2
+        )
+
+        new_storm_types = new_storm_types2.copy()
+        new_storm_embs = new_storm_embs2.copy()
+        new_dbzcomp_props = new_dbzcomp_props2.copy()
+        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+        new_storm_parent_labels = new_storm_parent_labels2.copy()
+        new_storm_depths = new_storm_depths2.copy()
+
+    if itr == max_itr and len(new_storm_depths)>0:
+
+        # If object embedded within QLCS_embedded object, discard the former
+        # If object embedded within AMORPHOUS or CELL is the only object embedded therein, discard it. If parent object is AMORPHOUS, reclassify it as discarded child object type.
+        # If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is unembedded, reclassify parent as CLUSTER or SUP_CLUSTER.
+        # If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is embedded in another object, remove parent since it we don't want embedded clusters
+
+        for depth in range(max(new_storm_depths), -1, -1):
+
+            if debug:
+                print("depth = %d" % depth)
+            remove_indices = []
+            parent_labels = []
+
+            for n, storm_type in enumerate(new_storm_types):
+
+                if new_storm_depths[n] == depth:  # and depth==2:
+
+                    if new_storm_embs[n] in ["EMB-QLCS999"]:
+
+                        parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+
+                        for nn, storm2_region in enumerate(new_dbzcomp_props):
+
+                            if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
+
+                                child_coords = np.asarray(storm2_region.coords)
+
+                                if check_overlap(child_coords, parent_coords):
+
+                                    if nn not in remove_indices:
+                                        remove_indices.append(nn)
+                                        parent_labels.append(new_dbzcomp_props[n].label)
+                                        if debug:
+                                            print(
+                                                "Removing %s within %s within %s"
+                                                % (
+                                                    new_storm_types[nn],
+                                                    storm_type,
+                                                    new_storm_embs[n][4:],
+                                                )
+                                            )
+
+                    elif new_storm_embs[n] in ["EMB-CELL", "EMB-CLUS"]:
+
+                        parent_label = new_storm_parent_labels[n]
+                        const_indices = [n]
+
+                        for nn in range(len(new_storm_types)):
+                            if new_dbzcomp_props[nn].label == parent_label:
+                                parent_index = nn
+                                break
+
+                        if new_storm_types[n] == "ROTATE":
+                            num_sups = 1
+                        else:
+                            num_sups = 0
+
+                        for nn in range(len(new_storm_types)):
+
+                            if nn != n and new_storm_parent_labels[nn] == parent_label:
+
+                                const_indices.append(nn)
+                                if new_storm_types[nn] == "ROTATE":
+                                    num_sups += 1
+
+                        if len(const_indices) == 1:
+                            if n not in remove_indices:
+                                remove_indices.append(n)
+                                parent_labels.append(parent_label)
+                                if new_storm_embs[n] == "EMB-CLUS":
+                                    new_storm_types2[parent_index] = storm_type
+                                if debug:
+                                    print(
+                                        "Removing singleton %s from %s (which is now a %s)"
+                                        % (
+                                            storm_type,
+                                            new_storm_types[parent_index],
+                                            storm_type,
+                                        )
+                                    )
+
+                        elif new_storm_embs[
+                            parent_index
+                        ] == "NONEMB" and new_storm_types[parent_index] not in [
+                            "CLUSTER",
+                            "SUP_CLUST",
+                        ]:
+
+                            if num_sups > 1:
+                                if debug:
+                                    print(
+                                        "Converting parent %s to SUP_CLUST"
+                                        % new_storm_types2[parent_index]
+                                    )
+                                new_storm_types2[parent_index] = "SUP_CLUST"
+                            else:
+                                if debug:
+                                    print(
+                                        "Converting parent %s to CLUSTER"
+                                        % new_storm_types2[parent_index]
+                                    )
+                                new_storm_types2[parent_index] = "CLUSTER"
+                            for ind in const_indices:
+                                new_storm_embs2[ind] = "EMB-CLUS"
+
+                        elif new_storm_embs[parent_index] != "NONEMB":
+
+                            if parent_index not in remove_indices:
+                                if debug:
+                                    print(
+                                        "Removing parent %s since it is actually an embedded cluster"
+                                        % new_storm_types[parent_index]
+                                    )
+                                remove_indices.append(parent_index)
+                                parent_labels.append(
+                                    new_storm_parent_labels[parent_index]
+                                )
+                                for ind in const_indices:
+                                    new_storm_embs2[ind] = "EMB-CLUS"
+
+            if len(remove_indices) != len(set(remove_indices)):
+                if debug:
+                    print("DUPLICATES in remove_indices!!! Exiting.")
+                    sys.exit(1)
+
+            for ind in sorted(remove_indices, reverse=True):
+                new_storm_types2.pop(ind)
+                new_storm_embs2.pop(ind)
+                new_dbzcomp_props2.pop(ind)
+                new_storm_parent_labels2.pop(ind)
+
+            (
+                new_storm_parent_labels2,
+                new_storm_embs2,
+                new_storm_depths2,
+            ) = object_hierarchy(new_storm_types2, new_dbzcomp_props2)
+
+            new_storm_types = new_storm_types2.copy()
+            new_storm_embs = new_storm_embs2.copy()
+            new_dbzcomp_props = new_dbzcomp_props2.copy()
+            new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+            new_storm_parent_labels = new_storm_parent_labels2.copy()
+            new_storm_depths = new_storm_depths2.copy()
+
+    if itr == max_itr:
+
+        for n, storm_type in enumerate(new_storm_types):
+
+            if new_storm_types[n] == "CLUSTER":
+
+                num_sup = 0
+                parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+
+                for nn, storm2_region in enumerate(new_dbzcomp_props):
+
+                    if (
+                        new_storm_types[nn] == "ROTATE"
+                        and new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area
+                    ):
+
+                        child_coords = np.asarray(storm2_region.coords)
+
+                        if check_overlap(child_coords, parent_coords):
+
+                            num_sup += 1
+
+                            if num_sup == 2:
+                                new_storm_types[n] = "SUP_CLUST"
+                                if debug:
+                                    print("CONVERTING CLUSTER TO SUP_CLUST!!! Exiting.")
+                                    sys.exit(1)
+                                break
+
+        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+            new_storm_types2, new_dbzcomp_props2
+        )
+
+        new_storm_types = new_storm_types2.copy()
+        new_storm_embs = new_storm_embs2.copy()
+        new_dbzcomp_props = new_dbzcomp_props2.copy()
+        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+        new_storm_parent_labels = new_storm_parent_labels2.copy()
+        new_storm_depths = new_storm_depths2.copy()
+
+    if itr == max_itr:
+
+        # Recast irregular discrete cell objects as AMORPHOUS
+
+        new_storm_types2 = list(new_storm_types)
+        new_storm_embs2 = list(new_storm_embs)
+        new_dbzcomp_props2 = list(new_dbzcomp_props)
+        new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
+
+        for n, storm_type in enumerate(new_storm_types):
+
+            if (
+                storm_type in ["ROTATE", "NONROT"]
+                and new_storm_embs[n] == "NONEMB"
+                and (
+                    new_dbzcomp_props[n].major_axis_length > 75 / 3.0
+                    or new_dbzcomp_props[n].solidity < 0.7
+                    or new_dbzcomp_props[n].eccentricity > 0.97
+                )
+            ):
+
+                new_storm_types2[n] = "AMORPHOUS"
+                if debug:
+                    print(
+                        "Converting DISCRETE CELL to AMORPHOUS",
+                        new_dbzcomp_props[n].area,
+                        new_dbzcomp_props[n].major_axis_length,
+                        new_dbzcomp_props[n].eccentricity,
+                        new_dbzcomp_props[n].solidity,
+                    )
+
+        new_storm_types = new_storm_types2
+        new_storm_embs = new_storm_embs2
+        new_dbzcomp_props = new_dbzcomp_props2
+        new_dbzcomp_labels = new_dbzcomp_labels2
+
+    if itr == max_itr:
+        return new_storm_types, new_storm_embs, new_dbzcomp_props, new_storm_depths2
+    else:
+        return new_storm_types, new_storm_embs, new_dbzcomp_props, None
+
+    return new_storm_types, new_storm_embs, new_dbzcomp_labels, new_dbzcomp_props
   
   
 @jit(fastmath=True) 
 def iterate_storm_types(storm_types, new_storm_types, new_dbzcomp_labels, 
-						dbz_coords,dbz_centroid,dbz_equiv_diam,dbz_area,
-						temp_storm_types, temp_coords,temp_prop_label,temp_dbzcomp_labels,
-						temp_centroid,temp_equiv_diam, temp_area, label_inc): 
-	
-	new_inds = []	
-	for n, storm_type in enumerate(storm_types):
-		
-		# Cycle through candidate storm objects
+                        dbz_coords,dbz_centroid,dbz_equiv_diam,dbz_area,
+                        temp_storm_types, temp_coords,temp_prop_label,temp_dbzcomp_labels,
+                        temp_centroid,temp_equiv_diam, temp_area, label_inc): 
+    
+    new_inds = []   
+    for n, storm_type in enumerate(storm_types):
+        
+        # Cycle through candidate storm objects
 
-		prelim_new_storm_types = []
-		prelim_new_dbzcomp_centroid = []
-		prelim_new_dbzcomp_equiv_diam= []
-		prelim_new_dbzcomp_area = []
-		prelim_temp_labels = []
-		temp_inds = []
+        prelim_new_storm_types = []
+        prelim_new_dbzcomp_centroid = []
+        prelim_new_dbzcomp_equiv_diam= []
+        prelim_new_dbzcomp_area = []
+        prelim_temp_labels = []
+        temp_inds = []
 
-		parent_coords = dbz_coords[n]
-		
-		for nn, prop in enumerate(temp_prop_label):
-			child_coords = temp_coords[nn]
-			if temp_storm_types[nn] in ["ROTATE", "NONROT"]:
-				
-				if check_overlap(child_coords, parent_coords):
-					# If candidate storm object overlaps an existing storm object,
-					# retain and characterize it for further testing
-					prelim_new_storm_types.append(temp_storm_types[nn])
-					temp_prop_label[
-						nn
-					] += label_inc	# ensure new object has unique label so as not to combine with preexisting object
-					prelim_new_dbzcomp_centroid.append(temp_centroid[nn])
-					prelim_new_dbzcomp_area.append(temp_area[nn])
-					prelim_new_dbzcomp_equiv_diam.append(temp_equiv_diam[nn])
-					prelim_temp_labels.append(temp_prop_label[nn])
-					temp_inds.append(nn)
+        parent_coords = dbz_coords[n]
+        
+        for nn, prop in enumerate(temp_prop_label):
+            child_coords = temp_coords[nn]
+            if temp_storm_types[nn] in ["ROTATE", "NONROT"]:
+                
+                if check_overlap(child_coords, parent_coords):
+                    # If candidate storm object overlaps an existing storm object,
+                    # retain and characterize it for further testing
+                    prelim_new_storm_types.append(temp_storm_types[nn])
+                    temp_prop_label[
+                        nn
+                    ] += label_inc  # ensure new object has unique label so as not to combine with preexisting object
+                    prelim_new_dbzcomp_centroid.append(temp_centroid[nn])
+                    prelim_new_dbzcomp_area.append(temp_area[nn])
+                    prelim_new_dbzcomp_equiv_diam.append(temp_equiv_diam[nn])
+                    prelim_temp_labels.append(temp_prop_label[nn])
+                    temp_inds.append(nn)
 
-		# cycle through each candidate new storm object
-		for nnn, new_storm_type in enumerate(prelim_new_storm_types):
+        # cycle through each candidate new storm object
+        for nnn, new_storm_type in enumerate(prelim_new_storm_types):
 
-			# if storm object is a CELL, determine if this object is likely just a smaller 
-			# version of an existing object (versus a constituent of a larger storm)
+            # if storm object is a CELL, determine if this object is likely just a smaller 
+            # version of an existing object (versus a constituent of a larger storm)
 
-			if new_storm_type in ["ROTATE", "NONROT"]:
+            if new_storm_type in ["ROTATE", "NONROT"]:
 
-				similar_storm_found = False
+                similar_storm_found = False
 
-				prelim_i = prelim_new_dbzcomp_centroid[nnn][0]
-				prelim_j = prelim_new_dbzcomp_centroid[nnn][1]
+                prelim_i = prelim_new_dbzcomp_centroid[nnn][0]
+                prelim_j = prelim_new_dbzcomp_centroid[nnn][1]
 
-				for nnnn, exist_props in enumerate(dbz_centroid):
+                for nnnn, exist_props in enumerate(dbz_centroid):
 
-					if new_storm_types[nnnn] in ["ROTATE", "NONROT"]:  ### NEW
+                    if new_storm_types[nnnn] in ["ROTATE", "NONROT"]:  ### NEW
 
-						exist_i = exist_props[0]
-						exist_j = exist_props[1]
-						dist = sqrt(
-							pow(prelim_i - exist_i, 2) + pow(prelim_j - exist_j, 2)
-						)
+                        exist_i = exist_props[0]
+                        exist_j = exist_props[1]
+                        dist = sqrt(
+                            pow(prelim_i - exist_i, 2) + pow(prelim_j - exist_j, 2)
+                        )
 
-						if (
-							dist < max(2, 0.15 * dbz_equiv_diam[nnn])
-							and prelim_new_dbzcomp_area[nnn] <= 1.0 * dbz_area[nnnn]
-						):
+                        if (
+                            dist < max(2, 0.15 * dbz_equiv_diam[nnn])
+                            and prelim_new_dbzcomp_area[nnn] <= 1.0 * dbz_area[nnnn]
+                        ):
 
-							similar_storm_found = True
-							break
+                            similar_storm_found = True
+                            break
 
-				# if candidate object is not merely a smaller version of an existing object, retain it
+                # if candidate object is not merely a smaller version of an existing object, retain it
 
-				if not similar_storm_found:
-					new_storm_types.append(prelim_new_storm_types[nnn])
-					new_inds.append(temp_inds[nnn])
-					dbz_centroid.append(prelim_new_dbzcomp_centroid[nnn])
-					dbz_area.append(prelim_new_dbzcomp_area[nnn])
-					dbz_equiv_diam.append(prelim_new_dbzcomp_equiv_diam[nnn])
-					new_dbzcomp_labels = whereeq(new_dbzcomp_labels.astype(np.int64),temp_dbzcomp_labels.astype(np.int64),
-					np.int64(prelim_temp_labels[nnn] - label_inc),np.int64(prelim_temp_labels[nnn])).astype(np.int8)
-					
-	return new_storm_types,new_dbzcomp_labels,new_inds
+                if not similar_storm_found:
+                    new_storm_types.append(prelim_new_storm_types[nnn])
+                    new_inds.append(temp_inds[nnn])
+                    dbz_centroid.append(prelim_new_dbzcomp_centroid[nnn])
+                    dbz_area.append(prelim_new_dbzcomp_area[nnn])
+                    dbz_equiv_diam.append(prelim_new_dbzcomp_equiv_diam[nnn])
+                    new_dbzcomp_labels = whereeq(new_dbzcomp_labels.astype(np.int64),temp_dbzcomp_labels.astype(np.int64),
+                    np.int64(prelim_temp_labels[nnn] - label_inc),np.int64(prelim_temp_labels[nnn])).astype(np.int8)
+                    
+    return new_storm_types,new_dbzcomp_labels,new_inds
 
  
 def get_storm_labels(storm_emb, storm_type):
 
-	convert_labels = {
-		"ROTATE": "SUPERCELL",
-		"NONROT": "ORDINARY",
-		"SEGMENT": "OTHER",
-		"QLCS": "QLCS",
-		"CLUSTER": "OTHER",
-		"AMORPHOUS": "OTHER",
-		"QLCS_ROT": "QLCS_MESO",
-		"QLCS_NON": "QLCS_ORD",
-		"CLUS_ROT": "SUPERCELL",
-		"CLUS_NON": "ORDINARY",
-		"SUP_CLUST": "SUP_CLUST",
-		"CELL_NON": "ORDINARY",
-		"CELL_ROT": "SUPERCELL",
-	}
-	digitize_types = {
-		key: n
-		for n, key in enumerate(
-			[
-				"ORDINARY",
-				"SUPERCELL",
-				"QLCS",
-				"SUP_CLUST",
-				"QLCS_ORD",
-				"QLCS_MESO",
-				"OTHER",
-			]
-		)
-	}
+    convert_labels = {
+        "ROTATE": "SUPERCELL",
+        "NONROT": "ORDINARY",
+        "SEGMENT": "OTHER",
+        "QLCS": "QLCS",
+        "CLUSTER": "OTHER",
+        "AMORPHOUS": "OTHER",
+        "QLCS_ROT": "QLCS_MESO",
+        "QLCS_NON": "QLCS_ORD",
+        "CLUS_ROT": "SUPERCELL",
+        "CLUS_NON": "ORDINARY",
+        "SUP_CLUST": "SUP_CLUST",
+        "CELL_NON": "ORDINARY",
+        "CELL_ROT": "SUPERCELL",
+    }
+    digitize_types = {
+        key: n
+        for n, key in enumerate(
+            [
+                "ORDINARY",
+                "SUPERCELL",
+                "QLCS",
+                "SUP_CLUST",
+                "QLCS_ORD",
+                "QLCS_MESO",
+                "OTHER",
+            ]
+        )
+    }
 
-	if storm_emb == "NONEMB":
-		label = storm_type
-	else:
-		label = "%s_%s" % (storm_emb[4:], storm_type[:3])
+    if storm_emb == "NONEMB":
+        label = storm_type
+    else:
+        label = "%s_%s" % (storm_emb[4:], storm_type[:3])
 
-	type_str = convert_labels[label]
-	type_int = int(digitize_types[type_str])
+    type_str = convert_labels[label]
+    type_int = int(digitize_types[type_str])
 
-	return type_int, type_str
+    return type_int, type_str
 
 
 def get_storm_types(
-	model,
-	qc_dbzcomp_labels,
-	qc_dbzcomp_props,
-	dbzcomp,
-	qc_uh_labels,
-	qc_uh_props,
-	uh,
-	ANALYSIS_DX, 
-	last_iter=False,
+    model,
+    qc_dbzcomp_labels,
+    qc_dbzcomp_props,
+    dbzcomp,
+    qc_uh_labels,
+    qc_uh_props,
+    uh,
+    ANALYSIS_DX, 
+    last_iter=False,
 ):
-	"""
-	# PURPOSE:
+    """
+    # PURPOSE:
 
-	# Classify storm objects based on REFLCOMP and UH5000/AZSHR fields
+    # Classify storm objects based on REFLCOMP and UH5000/AZSHR fields
 
-	# INPUTS:
+    # INPUTS:
 
-	# model (str), date (str), lead_time (int; mins) for which qc_dbzcomp_labels, etc. are valid
+    # model (str), date (str), lead_time (int; mins) for which qc_dbzcomp_labels, etc. are valid
 
-	# qc_dbzcomp_labels: single QC'd REFLCOMP 2-D label numpy array
-	# qc_dbzcomp_props: regionprops for each label in qc_dbzcomp_labels
-	# dbzcomp: 2-D REFLCOMP field from which qc_dbzcomp_labels, qc_dbzcomp_props generated
+    # qc_dbzcomp_labels: single QC'd REFLCOMP 2-D label numpy array
+    # qc_dbzcomp_props: regionprops for each label in qc_dbzcomp_labels
+    # dbzcomp: 2-D REFLCOMP field from which qc_dbzcomp_labels, qc_dbzcomp_props generated
 
-	# uh_labels/qc_uh_props/uh: as with qc_dbzcomp_labels/qc_dbzcomp_props/dbzcomp
+    # uh_labels/qc_uh_props/uh: as with qc_dbzcomp_labels/qc_dbzcomp_props/dbzcomp
 
-	# RETURNS:
+    # RETURNS:
 
-	# List of storm types (one for each regionprops in qc_dbzcomp_props, i.e., one for each REFLCOMP object)
+    # List of storm types (one for each regionprops in qc_dbzcomp_props, i.e., one for each REFLCOMP object)
 
-	# Author: Corey Potvin
-	"""
-	
-	storm_types = []
-	labels_with_matched_rotation = []
-	all_uh_coords = []
+    # Author: Corey Potvin
+    """
+    
+    storm_types = []
+    labels_with_matched_rotation = []
+    all_uh_coords = []
 
-	# Concatenate all coordinates of strong rotation, then identify regions with proximate rotation objects
+    # Concatenate all coordinates of strong rotation, then identify regions with proximate rotation objects
 
-	for n, qc_uh_prop in enumerate(qc_uh_props):
-		for coord in qc_uh_prop.coords:
-			all_uh_coords.append(coord)
-	all_uh_coords = np.asarray(all_uh_coords)
+    for n, qc_uh_prop in enumerate(qc_uh_props):
+        for coord in qc_uh_prop.coords:
+            all_uh_coords.append(coord)
+    all_uh_coords = np.asarray(all_uh_coords)
 
-	if len(all_uh_coords) > 0:
-		for qc_dbzcomp_prop in qc_dbzcomp_props:
-			ic, jc = int(qc_dbzcomp_prop.centroid[0]), int(qc_dbzcomp_prop.centroid[1])
-			rad = max(2, ceil(qc_dbzcomp_prop.equivalent_diameter / 3.0))
-			imin, imax = ic - rad, ic + rad
-			jmin, jmax = jc - rad, jc + rad
-			dbz_coords = []
-			for i in range(imin, imax + 1):
-				for j in range(jmin, jmax + 1):
-					dbz_coords.append([i, j])
-			dbz_coords = np.asarray(dbz_coords)
-			if check_overlap(dbz_coords, all_uh_coords):
-				labels_with_matched_rotation.append(qc_dbzcomp_prop.label)
+    if len(all_uh_coords) > 0:
+        for qc_dbzcomp_prop in qc_dbzcomp_props:
+            ic, jc = int(qc_dbzcomp_prop.centroid[0]), int(qc_dbzcomp_prop.centroid[1])
+            rad = max(2, ceil(qc_dbzcomp_prop.equivalent_diameter / 3.0))
+            imin, imax = ic - rad, ic + rad
+            jmin, jmax = jc - rad, jc + rad
+            dbz_coords = []
+            for i in range(imin, imax + 1):
+                for j in range(jmin, jmax + 1):
+                    dbz_coords.append([i, j])
+            dbz_coords = np.asarray(dbz_coords)
+            if check_overlap(dbz_coords, all_uh_coords):
+                labels_with_matched_rotation.append(qc_dbzcomp_prop.label)
 
-	for n, region in enumerate(qc_dbzcomp_props):
+    for n, region in enumerate(qc_dbzcomp_props):
 
-		# see scikit-image regionprops documentation for definitions of object attributes
+        # see scikit-image regionprops documentation for definitions of object attributes
 
-		DBZ_length = region.major_axis_length * ANALYSIS_DX
-		DBZ_area = region.area * pow(ANALYSIS_DX, 2)
+        DBZ_length = region.major_axis_length * ANALYSIS_DX
+        DBZ_area = region.area * pow(ANALYSIS_DX, 2)
 
-		if DBZ_area < 100e6 or (
-			DBZ_area < 200e6 and region.eccentricity < 0.7 and region.solidity > 0.7
-		):
+        if DBZ_area < 100e6 or (
+            DBZ_area < 200e6 and region.eccentricity < 0.7 and region.solidity > 0.7
+        ):
 
-			if region.label in labels_with_matched_rotation:
-				storm_type = "ROTATE"
-			else:
-				storm_type = "NONROT"
+            if region.label in labels_with_matched_rotation:
+                storm_type = "ROTATE"
+            else:
+                storm_type = "NONROT"
 
-		elif region.eccentricity > 0.97:
+        elif region.eccentricity > 0.97:
 
-			if DBZ_length > 75e3:
-				storm_type = "QLCS"
-			else:
-				storm_type = "AMORPHOUS"
+            if DBZ_length > 75e3:
+                storm_type = "QLCS"
+            else:
+                storm_type = "AMORPHOUS"
 
-		elif region.eccentricity > 0.9 and DBZ_length > 150e3:
-			storm_type = "QLCS"
+        elif region.eccentricity > 0.9 and DBZ_length > 150e3:
+            storm_type = "QLCS"
 
-		elif (
-			region.eccentricity > 0.93
-			or DBZ_area > 500e6
-			or DBZ_length > 75e3
-			or region.solidity < 0.7
-		):
-			storm_type = "AMORPHOUS"
+        elif (
+            region.eccentricity > 0.93
+            or DBZ_area > 500e6
+            or DBZ_length > 75e3
+            or region.solidity < 0.7
+        ):
+            storm_type = "AMORPHOUS"
 
-		elif region.label in labels_with_matched_rotation:
-			storm_type = "ROTATE"
+        elif region.label in labels_with_matched_rotation:
+            storm_type = "ROTATE"
 
-		else:
-			storm_type = "NONROT"
+        else:
+            storm_type = "NONROT"
 
-		# if storm_type in ['ROTATE', 'NONROT'] and (DBZ_length > 75e3 or region.solidity < 0.7 or region.eccentricity > 0.97):
-		#  storm_type = 'AMORPHOUS'
+        # if storm_type in ['ROTATE', 'NONROT'] and (DBZ_length > 75e3 or region.solidity < 0.7 or region.eccentricity > 0.97):
+        #  storm_type = 'AMORPHOUS'
 
-		storm_types.append(storm_type)
+        storm_types.append(storm_type)
 
-	return storm_types, labels_with_matched_rotation
+    return storm_types, labels_with_matched_rotation
 
 @jit
 def check_overlap(coords1, coords2):
 
-	for item1 in coords1:
-		for item2 in coords2:
-			if (item1 == item2).all():
-				return True
+    for item1 in coords1:
+        for item2 in coords2:
+            if (item1 == item2).all():
+                return True
 
-	return False
+    return False
 
 
 def object_hierarchy(storm_types, dbzcomp_props):
 
-	storm_parent_labels = list(np.zeros(len(storm_types)))
-	storm_embs = list(np.zeros(len(storm_types)))
+    storm_parent_labels = list(np.zeros(len(storm_types)))
+    storm_embs = list(np.zeros(len(storm_types)))
 
-	for n, storm_type in enumerate(storm_types):
+    for n, storm_type in enumerate(storm_types):
 
-		child_coords = np.asarray(dbzcomp_props[n].coords)
-		min_potential_parent_area = 9999999999
-		parent_found = False
+        child_coords = np.asarray(dbzcomp_props[n].coords)
+        min_potential_parent_area = 9999999999
+        parent_found = False
 
-		for nn in range(len(dbzcomp_props)):
-			potential_parent_area = dbzcomp_props[nn].area
-			if potential_parent_area > dbzcomp_props[n].area:
-				potential_parent_coords = np.asarray(dbzcomp_props[nn].coords)
-				if check_overlap(child_coords, potential_parent_coords):
-					parent_found = True
-					if potential_parent_area < min_potential_parent_area:
-						min_potential_parent_area = potential_parent_area
-						potential_parent_index = nn
+        for nn in range(len(dbzcomp_props)):
+            potential_parent_area = dbzcomp_props[nn].area
+            if potential_parent_area > dbzcomp_props[n].area:
+                potential_parent_coords = np.asarray(dbzcomp_props[nn].coords)
+                if check_overlap(child_coords, potential_parent_coords):
+                    parent_found = True
+                    if potential_parent_area < min_potential_parent_area:
+                        min_potential_parent_area = potential_parent_area
+                        potential_parent_index = nn
 
-		if parent_found:
-			storm_parent_labels[n] = dbzcomp_props[potential_parent_index].label
-			if storm_types[potential_parent_index] == "QLCS":
-				storm_embs[n] = "EMB-QLCS"
-			elif storm_types[potential_parent_index] in [
-				"CLUSTER",
-				"AMORPHOUS",
-				"SUP_CLUST",
-			]:
-				storm_embs[n] = "EMB-CLUS"
-			else:
-				storm_embs[n] = "EMB-CELL"
-		else:
-			storm_embs[n] = "NONEMB"
+        if parent_found:
+            storm_parent_labels[n] = dbzcomp_props[potential_parent_index].label
+            if storm_types[potential_parent_index] == "QLCS":
+                storm_embs[n] = "EMB-QLCS"
+            elif storm_types[potential_parent_index] in [
+                "CLUSTER",
+                "AMORPHOUS",
+                "SUP_CLUST",
+            ]:
+                storm_embs[n] = "EMB-CLUS"
+            else:
+                storm_embs[n] = "EMB-CELL"
+        else:
+            storm_embs[n] = "NONEMB"
 
-		storm_labels = [props.label for props in dbzcomp_props]
+        storm_labels = [props.label for props in dbzcomp_props]
 
-	storm_depths = []
+    storm_depths = []
 
-	for n in range(len(storm_parent_labels)):
+    for n in range(len(storm_parent_labels)):
 
-		depth = 0
-		nn = n
+        depth = 0
+        nn = n
 
-		while storm_parent_labels[nn] > 0:
+        while storm_parent_labels[nn] > 0:
 
-			depth += 1
-			parent_label = storm_parent_labels[nn]
-			nn = storm_labels.index(parent_label)
+            depth += 1
+            parent_label = storm_parent_labels[nn]
+            nn = storm_labels.index(parent_label)
 
-		storm_depths.append(depth)
-		# print (n, storm_types[n], depth)
+        storm_depths.append(depth)
+        # print (n, storm_types[n], depth)
 
-	return storm_parent_labels, storm_embs, storm_depths
+    return storm_parent_labels, storm_embs, storm_depths

--- a/monte_python/_mode_classifier.py
+++ b/monte_python/_mode_classifier.py
@@ -2,7 +2,7 @@ import copy
 import xarray as xr
 
 import numpy as np
-from numba import jit, float32, int32
+from numba import jit
 from math import atan2, ceil, pi, log, sqrt, pow, fabs, cos, sin
 from skimage.measure import regionprops, label
 from .object_identification import label
@@ -37,7 +37,6 @@ def get_constituent_storms(
 
     label_inc = 100 * (itr - 1)
     
-    t1 = time()
     temp_dbzcomp_labels, temp_dbzcomp_props = label(
         input_data=dbzcomp_values,
         method="single_threshold",
@@ -46,7 +45,6 @@ def get_constituent_storms(
     
     if len(temp_dbzcomp_props) > 0:
         # Apply quality control
-        t1 = time()
         temp_dbzcomp_labels, temp_dbzcomp_props = QualityControler().quality_control(
             object_labels=temp_dbzcomp_labels,
             object_properties=temp_dbzcomp_props,
@@ -55,7 +53,6 @@ def get_constituent_storms(
         )
 
     # Identify candidate embedded storm objects
-    t1 = time()
     temp_storm_types, labels_with_matched_rotation = get_storm_types(
         model,
         temp_dbzcomp_labels,

--- a/monte_python/_mode_classifier.py
+++ b/monte_python/_mode_classifier.py
@@ -2,772 +2,814 @@ import copy
 import xarray as xr
 
 import numpy as np
+from numba import jit, float32, int32
 from math import atan2, ceil, pi, log, sqrt, pow, fabs, cos, sin
 from skimage.measure import regionprops, label
 from .object_identification import label
-from .object_quality_control import QualityControler
+from .object_quality_control import QualityControler, whereeq
+from numba.core.errors import NumbaDeprecationWarning, NumbaPendingDeprecationWarning
+import warnings
+from time import time
+
+warnings.simplefilter('ignore', category=NumbaDeprecationWarning)
+warnings.simplefilter('ignore', category=NumbaPendingDeprecationWarning)
 
 #ANALYSIS_DX = 3000
 
 def get_constituent_storms(
-    model,
-    min_thresh,
-    dbzcomp_qc_params, 
-    storm_types,
-    dbzcomp_labels,
-    dbzcomp_props,
-    dbzcomp_values,
-    uh_labels,
-    uh_props,
-    uh_values,
-    itr,
-    max_itr,
-    ANALYSIS_DX, 
-    debug=False,
+	model,
+	min_thresh,
+	dbzcomp_qc_params, 
+	storm_types,
+	dbzcomp_labels,
+	dbzcomp_props,
+	dbzcomp_values,
+	uh_labels,
+	uh_props,
+	uh_values,
+	itr,
+	max_itr,
+	ANALYSIS_DX, 
+	debug=False,
 ):
+	new_storm_types = storm_types.copy()
+	new_dbzcomp_labels = dbzcomp_labels.copy()
+	new_dbzcomp_props = dbzcomp_props.copy()
+
+	label_inc = 100 * (itr - 1)
+	
+	t1 = time()
+	temp_dbzcomp_labels, temp_dbzcomp_props = label(
+		input_data=dbzcomp_values,
+		method="single_threshold",
+		params={"bdry_thresh": min_thresh},
+	)
+	
+	if len(temp_dbzcomp_props) > 0:
+		# Apply quality control
+		t1 = time()
+		temp_dbzcomp_labels, temp_dbzcomp_props = QualityControler().quality_control(
+			object_labels=temp_dbzcomp_labels,
+			object_properties=temp_dbzcomp_props,
+			input_data=dbzcomp_values,
+			qc_params=dbzcomp_qc_params,
+		)
+
+	# Identify candidate embedded storm objects
+	t1 = time()
+	temp_storm_types, labels_with_matched_rotation = get_storm_types(
+		model,
+		temp_dbzcomp_labels,
+		temp_dbzcomp_props,
+		dbzcomp_values,
+		uh_labels,
+		uh_props,
+		uh_values,
+		ANALYSIS_DX, 
+		itr == max_itr,
+	)
+	
+	dbz_coords = [prop.coords for prop in dbzcomp_props]
+	if (len(temp_storm_types)):
+		new_storm_types,new_dbzcomp_labels,n_append = iterate_storm_types(
+						storm_types, new_storm_types,new_dbzcomp_labels,
+						dbz_coords, 
+						[prop.centroid for prop in dbzcomp_props],
+						[prop.equivalent_diameter for prop in dbzcomp_props], 
+						[prop.area for prop in dbzcomp_props],
+						temp_storm_types, 
+						[prop.coords for prop in temp_dbzcomp_props], 
+						[prop.label for prop in temp_dbzcomp_props],
+						temp_dbzcomp_labels,
+						[prop.centroid for prop in temp_dbzcomp_props], 
+						[prop.equivalent_diameter for prop in temp_dbzcomp_props],
+						[prop.area for prop in temp_dbzcomp_props],
+						label_inc
+						)
+						
+		for n in n_append:
+			new_dbzcomp_props.append(temp_dbzcomp_props[n])
+
+	# After last iteration, do final QC
+
+	if itr == max_itr:
+
+		# Create "family tree" of objects; new_storm_depths contains the "generation" of each object; 
+		# new_storm_parent_labels contains the parent label for each child object; new_storm_embs 
+		# contains the parent type of each child object
+		# new_storm_depths is later used to process objects in order of their generation
+
+		new_storm_parent_labels, new_storm_embs, new_storm_depths = object_hierarchy(
+			new_storm_types, new_dbzcomp_props
+		)
+
+		new_storm_types2 = new_storm_types.copy()
+		new_storm_embs2 = new_storm_embs.copy()
+		new_dbzcomp_props2 = new_dbzcomp_props.copy()
+		new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
+		new_storm_parent_labels2 = new_storm_parent_labels.copy()
+		new_storm_depths2 = new_storm_depths.copy()
+
+	else:
+
+		new_storm_embs = ["NONEMB" for x in new_storm_types]
+
+	if itr == max_itr:
+
+		remove_indices = []
+		parent_labels = []
+
+		for n, storm_type in enumerate(new_storm_types):
+
+			if new_storm_embs[n] in ["EMB-QLCS"]:
+
+				"""parent_label = new_dbzcomp_props[n].label
+
+				for nn in range(len(new_storm_types)):
+				  if nn != n and new_storm_parent_labels[nn] == parent_label:
+					if nn not in remove_indices:
+					  remove_indices.append(nn)
+					  print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
+
+				parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+
+				for nn, storm2_region in enumerate(new_dbzcomp_props):
+
+					if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
+
+						child_coords = np.asarray(storm2_region.coords)
+
+						if check_overlap(child_coords, parent_coords):
 
-    new_storm_types = storm_types.copy()
-    new_dbzcomp_labels = dbzcomp_labels.copy()
-    new_dbzcomp_props = dbzcomp_props.copy()
+							if nn not in remove_indices:
+								remove_indices.append(nn)
+								parent_labels.append(new_storm_parent_labels[nn])
+								if debug:
+									print(
+										"Removing %s within %s within %s"
+										% (
+											new_storm_types[nn],
+											storm_type,
+											new_storm_embs[n][4:],
+										)
+									)
 
-    label_inc = 100 * (itr - 1)
+		for ind in sorted(remove_indices, reverse=True):
+			new_storm_types2.pop(ind)
+			new_storm_embs2.pop(ind)
+			new_dbzcomp_props2.pop(ind)
+			new_storm_parent_labels2.pop(ind)
 
-    temp_dbzcomp_labels, temp_dbzcomp_props = label(
-        input_data=dbzcomp_values,
-        method="single_threshold",
-        params={"bdry_thresh": min_thresh},
-    )
+		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+			new_storm_types2, new_dbzcomp_props2
+		)
 
-    if len(temp_dbzcomp_props) > 0:
+		new_storm_types = new_storm_types2.copy()
+		new_storm_embs = new_storm_embs2.copy()
+		new_dbzcomp_props = new_dbzcomp_props2.copy()
+		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+		new_storm_parent_labels = new_storm_parent_labels2.copy()
+		new_storm_depths = new_storm_depths2.copy()
 
-        # Apply quality control
-        temp_dbzcomp_labels, temp_dbzcomp_props = QualityControler().quality_control(
-            object_labels=temp_dbzcomp_labels,
-            object_properties=temp_dbzcomp_props,
-            input_data=dbzcomp_values,
-            qc_params=dbzcomp_qc_params,
-        )
+	if itr == max_itr:
 
-    # Identify candidate embedded storm objects
+		# Reclassify QLCS as cluster if object area dominated by CELLs
 
-    temp_storm_types, labels_with_matched_rotation = get_storm_types(
-        model,
-        temp_dbzcomp_labels,
-        temp_dbzcomp_props,
-        dbzcomp_values,
-        uh_labels,
-        uh_props,
-        uh_values,
-        ANALYSIS_DX, 
-        itr == max_itr,
-    )
+		for n, storm_type in enumerate(new_storm_types):
 
-    for n, storm_type in enumerate(storm_types):
+			if (
+				new_storm_types[n] == "QLCS"
+				and new_dbzcomp_props[n].major_axis_length < 150 / 3.0
+			):
 
-        # Cycle through candidate storm objects
+				num_const = 0
+				num_rot = 0
+				const_area = 0
+
+				for nn in range(len(new_storm_types)):
+
+					if (
+						nn != n
+						and new_storm_parent_labels[nn] == new_dbzcomp_props[n].label
+					):
 
-        prelim_new_storm_types = []
-        prelim_new_dbzcomp_props = []
-        prelim_temp_labels = []
+						num_const += 1
+						if new_storm_types[nn] == "ROTATE":
+							num_rot += 1
+						const_area += new_dbzcomp_props[nn].area
 
-        parent_coords = np.asarray(dbzcomp_props[n].coords)
+				const_area_frac = const_area / float(new_dbzcomp_props[n].area)
 
-        for nn, temp_dbzcomp_prop in enumerate(temp_dbzcomp_props):
+				if const_area_frac > 0.75:
+
+					if num_rot > 1:
+						new_storm_types2[n] = "SUP_CLUST"
+					elif num_const > 1:
+						new_storm_types2[n] = "CLUSTER"
+					else:
+						new_storm_types2[n] = "AMORPHOUS"
+					if debug:
+						print(
+							"CONVERTING QLCS to %s since const_area_frac = %.2f"
+							% (new_storm_types2[n], const_area_frac)
+						)
 
-            if temp_storm_types[nn] in ["ROTATE", "NONROT"]:
-                child_coords = np.asarray(temp_dbzcomp_prop.coords)
-                if check_overlap(child_coords, parent_coords):
-                    # If candidate storm object overlaps an existing storm object, retain and characterize it for further testing
-                    prelim_new_storm_types.append(temp_storm_types[nn])
-                    temp_dbzcomp_props[
-                        nn
-                    ].label += label_inc  # ensure new object has unique label so as not to combine with preexisting object
-                    prelim_new_dbzcomp_props.append(temp_dbzcomp_props[nn])
-                    prelim_temp_labels.append(temp_dbzcomp_props[nn].label)
+				else:
 
-        # if len(prelim_new_dbzcomp_props) > 0:
+					if debug:
+						print(
+							"RETAINING QLCS since const_area_frac = %.2f"
+							% const_area_frac
+						)
 
-        # cycle through each candidate new storm object
+		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+			new_storm_types2, new_dbzcomp_props2
+		)
 
-        for nnn, new_storm_type in enumerate(prelim_new_storm_types):
+		new_storm_types = new_storm_types2.copy()
+		new_storm_embs = new_storm_embs2.copy()
+		new_dbzcomp_props = new_dbzcomp_props2.copy()
+		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+		new_storm_parent_labels = new_storm_parent_labels2.copy()
+		new_storm_depths = new_storm_depths2.copy()
 
-            # if storm object is a CELL, determine if this object is likely just a smaller version of an existing object (versus a constituent of a larger storm)
+	if itr == max_itr + 999:
 
-            if new_storm_type in ["ROTATE", "NONROT"]:
+		remove_indices = []
 
-                similar_storm_found = False
+		for n, storm_type in enumerate(new_storm_types):
 
-                prelim_props = prelim_new_dbzcomp_props[nnn]
-                prelim_i = prelim_props.centroid[0]
-                prelim_j = prelim_props.centroid[1]
+			if new_storm_embs[n] in ["EMB-QLCS"]:
 
-                for nnnn, exist_props in enumerate(new_dbzcomp_props):
+				"""parent_label = new_dbzcomp_props[n].label
 
-                    if new_storm_types[nnnn] in ["ROTATE", "NONROT"]:  ### NEW
+				for nn in range(len(new_storm_types)):
+				  if nn != n and new_storm_parent_labels[nn] == parent_label:
+					if nn not in remove_indices:
+					  remove_indices.append(nn)
+					  print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
 
-                        exist_i = exist_props.centroid[0]
-                        exist_j = exist_props.centroid[1]
-                        dist = sqrt(
-                            pow(prelim_i - exist_i, 2) + pow(prelim_j - exist_j, 2)
-                        )
+				parent_coords = np.asarray(new_dbzcomp_props[n].coords)
 
-                        if (
-                            dist < max(2, 0.15 * exist_props.equivalent_diameter)
-                            and prelim_props.area <= 1.0 * exist_props.area
-                        ):
+				for nn, storm2_region in enumerate(new_dbzcomp_props):
 
-                            similar_storm_found = True
-                            break
+					if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
 
-                # if candidate object is not merely a smaller version of an existing object, retain it
+						child_coords = np.asarray(storm2_region.coords)
 
-                if not similar_storm_found:
-                    new_storm_types.append(prelim_new_storm_types[nnn])
-                    new_dbzcomp_props.append(prelim_new_dbzcomp_props[nnn])
+						if check_overlap(child_coords, parent_coords):
 
-                    # insert new object into label image
-                    new_dbzcomp_labels[
-                        temp_dbzcomp_labels == (prelim_temp_labels[nnn] - label_inc)
-                    ] = prelim_temp_labels[nnn]
+							if nn not in remove_indices:
+								remove_indices.append(nn)
+								if debug:
+									print(
+										"Removing %s within %s within %s"
+										% (
+											new_storm_types[nn],
+											storm_type,
+											new_storm_embs[n][4:],
+										)
+									)
 
-    # if itr!=max_itr and (len(new_dbzcomp_props) != len(set(new_dbzcomp_labels.flatten().tolist()))-1 or len(new_dbzcomp_props) != len(new_storm_types)):
-    #  print ('CCCCCCCCCCCCC', len(new_dbzcomp_props), len(set(new_dbzcomp_labels.flatten().tolist()))-1, len(new_storm_types))
-
-    # After last iteration, do final QC
-
-    if itr == max_itr:
-
-        # Create "family tree" of objects; new_storm_depths contains the "generation" of each object; new_storm_parent_labels contains the parent label for each child object; new_storm_embs contains the parent type of each child object
-        # new_storm_depths is later used to process objects in order of their generation
-
-        new_storm_parent_labels, new_storm_embs, new_storm_depths = object_hierarchy(
-            new_storm_types, new_dbzcomp_props
-        )
-
-        new_storm_types2 = new_storm_types.copy()
-        new_storm_embs2 = new_storm_embs.copy()
-        new_dbzcomp_props2 = new_dbzcomp_props.copy()
-        new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
-        new_storm_parent_labels2 = new_storm_parent_labels.copy()
-        new_storm_depths2 = new_storm_depths.copy()
-
-    else:
-
-        new_storm_embs = ["NONEMB" for x in new_storm_types]
-
-    if itr == max_itr:
-
-        remove_indices = []
-        parent_labels = []
-
-        for n, storm_type in enumerate(new_storm_types):
-
-            if new_storm_embs[n] in ["EMB-QLCS"]:
-
-                """parent_label = new_dbzcomp_props[n].label
-
-                for nn in range(len(new_storm_types)):
-                  if nn != n and new_storm_parent_labels[nn] == parent_label:
-                    if nn not in remove_indices:
-                      remove_indices.append(nn)
-                      print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
-
-                parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-                for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-                    if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
-
-                        child_coords = np.asarray(storm2_region.coords)
-
-                        if check_overlap(child_coords, parent_coords):
-
-                            if nn not in remove_indices:
-                                remove_indices.append(nn)
-                                parent_labels.append(new_storm_parent_labels[nn])
-                                if debug:
-                                    print(
-                                        "Removing %s within %s within %s"
-                                        % (
-                                            new_storm_types[nn],
-                                            storm_type,
-                                            new_storm_embs[n][4:],
-                                        )
-                                    )
-
-        for ind in sorted(remove_indices, reverse=True):
-            new_storm_types2.pop(ind)
-            new_storm_embs2.pop(ind)
-            new_dbzcomp_props2.pop(ind)
-            new_storm_parent_labels2.pop(ind)
-
-        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-            new_storm_types2, new_dbzcomp_props2
-        )
-
-        new_storm_types = new_storm_types2.copy()
-        new_storm_embs = new_storm_embs2.copy()
-        new_dbzcomp_props = new_dbzcomp_props2.copy()
-        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-        new_storm_parent_labels = new_storm_parent_labels2.copy()
-        new_storm_depths = new_storm_depths2.copy()
-
-    if itr == max_itr:
-
-        # Reclassify QLCS as cluster if object area dominated by CELLs
-
-        for n, storm_type in enumerate(new_storm_types):
-
-            if (
-                new_storm_types[n] == "QLCS"
-                and new_dbzcomp_props[n].major_axis_length < 150 / 3.0
-            ):
-
-                num_const = 0
-                num_rot = 0
-                const_area = 0
-
-                for nn in range(len(new_storm_types)):
-
-                    if (
-                        nn != n
-                        and new_storm_parent_labels[nn] == new_dbzcomp_props[n].label
-                    ):
-
-                        num_const += 1
-                        if new_storm_types[nn] == "ROTATE":
-                            num_rot += 1
-                        const_area += new_dbzcomp_props[nn].area
-
-                const_area_frac = const_area / float(new_dbzcomp_props[n].area)
-
-                if const_area_frac > 0.75:
-
-                    if num_rot > 1:
-                        new_storm_types2[n] = "SUP_CLUST"
-                    elif num_const > 1:
-                        new_storm_types2[n] = "CLUSTER"
-                    else:
-                        new_storm_types2[n] = "AMORPHOUS"
-                    if debug:
-                        print(
-                            "CONVERTING QLCS to %s since const_area_frac = %.2f"
-                            % (new_storm_types2[n], const_area_frac)
-                        )
-
-                else:
-
-                    if debug:
-                        print(
-                            "RETAINING QLCS since const_area_frac = %.2f"
-                            % const_area_frac
-                        )
-
-        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-            new_storm_types2, new_dbzcomp_props2
-        )
-
-        new_storm_types = new_storm_types2.copy()
-        new_storm_embs = new_storm_embs2.copy()
-        new_dbzcomp_props = new_dbzcomp_props2.copy()
-        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-        new_storm_parent_labels = new_storm_parent_labels2.copy()
-        new_storm_depths = new_storm_depths2.copy()
-
-    if itr == max_itr + 999:
-
-        remove_indices = []
-
-        for n, storm_type in enumerate(new_storm_types):
-
-            if new_storm_embs[n] in ["EMB-QLCS"]:
-
-                """parent_label = new_dbzcomp_props[n].label
-
-                for nn in range(len(new_storm_types)):
-                  if nn != n and new_storm_parent_labels[nn] == parent_label:
-                    if nn not in remove_indices:
-                      remove_indices.append(nn)
-                      print ("Removing %s within %s within QLCS" % (new_storm_types[nn], storm_type))"""
-
-                parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-                for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-                    if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
-
-                        child_coords = np.asarray(storm2_region.coords)
-
-                        if check_overlap(child_coords, parent_coords):
-
-                            if nn not in remove_indices:
-                                remove_indices.append(nn)
-                                if debug:
-                                    print(
-                                        "Removing %s within %s within %s"
-                                        % (
-                                            new_storm_types[nn],
-                                            storm_type,
-                                            new_storm_embs[n][4:],
-                                        )
-                                    )
-
-        for ind in sorted(remove_indices, reverse=True):
-            new_storm_types2.pop(ind)
-            new_storm_embs2.pop(ind)
-            new_dbzcomp_props2.pop(ind)
-            new_storm_parent_labels2.pop(ind)
-
-        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-            new_storm_types2, new_dbzcomp_props2
-        )
-
-        new_storm_types = new_storm_types2.copy()
-        new_storm_embs = new_storm_embs2.copy()
-        new_dbzcomp_props = new_dbzcomp_props2.copy()
-        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-        new_storm_parent_labels = new_storm_parent_labels2.copy()
-        new_storm_depths = new_storm_depths2.copy()
-
-    if itr == max_itr:
-
-        # If object embedded within QLCS_embedded object, discard the former
-        # If object embedded within AMORPHOUS or CELL is the only object embedded therein, discard it. If parent object is AMORPHOUS, reclassify it as discarded child object type.
-        # If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is unembedded, reclassify parent as CLUSTER or SUP_CLUSTER.
-        # If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is embedded in another object, remove parent since it we don't want embedded clusters
-
-        for depth in range(max(new_storm_depths), -1, -1):
-
-            if debug:
-                print("depth = %d" % depth)
-            remove_indices = []
-            parent_labels = []
-
-            for n, storm_type in enumerate(new_storm_types):
-
-                if new_storm_depths[n] == depth:  # and depth==2:
-
-                    if new_storm_embs[n] in ["EMB-QLCS999"]:
-
-                        parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-                        for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-                            if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
-
-                                child_coords = np.asarray(storm2_region.coords)
-
-                                if check_overlap(child_coords, parent_coords):
-
-                                    if nn not in remove_indices:
-                                        remove_indices.append(nn)
-                                        parent_labels.append(new_dbzcomp_props[n].label)
-                                        if debug:
-                                            print(
-                                                "Removing %s within %s within %s"
-                                                % (
-                                                    new_storm_types[nn],
-                                                    storm_type,
-                                                    new_storm_embs[n][4:],
-                                                )
-                                            )
-
-                    elif new_storm_embs[n] in ["EMB-CELL", "EMB-CLUS"]:
-
-                        parent_label = new_storm_parent_labels[n]
-                        const_indices = [n]
-
-                        for nn in range(len(new_storm_types)):
-                            if new_dbzcomp_props[nn].label == parent_label:
-                                parent_index = nn
-                                break
-
-                        if new_storm_types[n] == "ROTATE":
-                            num_sups = 1
-                        else:
-                            num_sups = 0
-
-                        for nn in range(len(new_storm_types)):
-
-                            if nn != n and new_storm_parent_labels[nn] == parent_label:
-
-                                const_indices.append(nn)
-                                if new_storm_types[nn] == "ROTATE":
-                                    num_sups += 1
-
-                        if len(const_indices) == 1:
-                            if n not in remove_indices:
-                                remove_indices.append(n)
-                                parent_labels.append(parent_label)
-                                if new_storm_embs[n] == "EMB-CLUS":
-                                    new_storm_types2[parent_index] = storm_type
-                                if debug:
-                                    print(
-                                        "Removing singleton %s from %s (which is now a %s)"
-                                        % (
-                                            storm_type,
-                                            new_storm_types[parent_index],
-                                            storm_type,
-                                        )
-                                    )
-
-                        elif new_storm_embs[
-                            parent_index
-                        ] == "NONEMB" and new_storm_types[parent_index] not in [
-                            "CLUSTER",
-                            "SUP_CLUST",
-                        ]:
-
-                            if num_sups > 1:
-                                if debug:
-                                    print(
-                                        "Converting parent %s to SUP_CLUST"
-                                        % new_storm_types2[parent_index]
-                                    )
-                                new_storm_types2[parent_index] = "SUP_CLUST"
-                            else:
-                                if debug:
-                                    print(
-                                        "Converting parent %s to CLUSTER"
-                                        % new_storm_types2[parent_index]
-                                    )
-                                new_storm_types2[parent_index] = "CLUSTER"
-                            for ind in const_indices:
-                                new_storm_embs2[ind] = "EMB-CLUS"
-
-                        elif new_storm_embs[parent_index] != "NONEMB":
-
-                            if parent_index not in remove_indices:
-                                if debug:
-                                    print(
-                                        "Removing parent %s since it is actually an embedded cluster"
-                                        % new_storm_types[parent_index]
-                                    )
-                                remove_indices.append(parent_index)
-                                parent_labels.append(
-                                    new_storm_parent_labels[parent_index]
-                                )
-                                for ind in const_indices:
-                                    new_storm_embs2[ind] = "EMB-CLUS"
-
-            if len(remove_indices) != len(set(remove_indices)):
-                if debug:
-                    print("DUPLICATES in remove_indices!!! Exiting.")
-                    sys.exit(1)
-
-            for ind in sorted(remove_indices, reverse=True):
-                new_storm_types2.pop(ind)
-                new_storm_embs2.pop(ind)
-                new_dbzcomp_props2.pop(ind)
-                new_storm_parent_labels2.pop(ind)
-
-            (
-                new_storm_parent_labels2,
-                new_storm_embs2,
-                new_storm_depths2,
-            ) = object_hierarchy(new_storm_types2, new_dbzcomp_props2)
-
-            new_storm_types = new_storm_types2.copy()
-            new_storm_embs = new_storm_embs2.copy()
-            new_dbzcomp_props = new_dbzcomp_props2.copy()
-            new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-            new_storm_parent_labels = new_storm_parent_labels2.copy()
-            new_storm_depths = new_storm_depths2.copy()
-
-    if itr == max_itr:
-
-        for n, storm_type in enumerate(new_storm_types):
-
-            if new_storm_types[n] == "CLUSTER":
-
-                num_sup = 0
-                parent_coords = np.asarray(new_dbzcomp_props[n].coords)
-
-                for nn, storm2_region in enumerate(new_dbzcomp_props):
-
-                    if (
-                        new_storm_types[nn] == "ROTATE"
-                        and new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area
-                    ):
-
-                        child_coords = np.asarray(storm2_region.coords)
-
-                        if check_overlap(child_coords, parent_coords):
-
-                            num_sup += 1
-
-                            if num_sup == 2:
-                                new_storm_types[n] = "SUP_CLUST"
-                                if debug:
-                                    print("CONVERTING CLUSTER TO SUP_CLUST!!! Exiting.")
-                                    sys.exit(1)
-                                break
-
-        new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
-            new_storm_types2, new_dbzcomp_props2
-        )
-
-        new_storm_types = new_storm_types2.copy()
-        new_storm_embs = new_storm_embs2.copy()
-        new_dbzcomp_props = new_dbzcomp_props2.copy()
-        new_dbzcomp_labels = new_dbzcomp_labels2.copy()
-        new_storm_parent_labels = new_storm_parent_labels2.copy()
-        new_storm_depths = new_storm_depths2.copy()
-
-    if itr == max_itr:
-
-        # Recast irregular discrete cell objects as AMORPHOUS
-
-        new_storm_types2 = list(new_storm_types)
-        new_storm_embs2 = list(new_storm_embs)
-        new_dbzcomp_props2 = list(new_dbzcomp_props)
-        new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
-
-        for n, storm_type in enumerate(new_storm_types):
-
-            if (
-                storm_type in ["ROTATE", "NONROT"]
-                and new_storm_embs[n] == "NONEMB"
-                and (
-                    new_dbzcomp_props[n].major_axis_length > 75 / 3.0
-                    or new_dbzcomp_props[n].solidity < 0.7
-                    or new_dbzcomp_props[n].eccentricity > 0.97
-                )
-            ):
-
-                new_storm_types2[n] = "AMORPHOUS"
-                if debug:
-                    print(
-                        "Converting DISCRETE CELL to AMORPHOUS",
-                        new_dbzcomp_props[n].area,
-                        new_dbzcomp_props[n].major_axis_length,
-                        new_dbzcomp_props[n].eccentricity,
-                        new_dbzcomp_props[n].solidity,
-                    )
-
-        new_storm_types = new_storm_types2
-        new_storm_embs = new_storm_embs2
-        new_dbzcomp_props = new_dbzcomp_props2
-        new_dbzcomp_labels = new_dbzcomp_labels2
-
-    if itr == max_itr:
-        return new_storm_types, new_storm_embs, new_dbzcomp_props, new_storm_depths2
-    else:
-        return new_storm_types, new_storm_embs, new_dbzcomp_props, None
-
-    return new_storm_types, new_storm_embs, new_dbzcomp_labels, new_dbzcomp_props
-
+		for ind in sorted(remove_indices, reverse=True):
+			new_storm_types2.pop(ind)
+			new_storm_embs2.pop(ind)
+			new_dbzcomp_props2.pop(ind)
+			new_storm_parent_labels2.pop(ind)
+
+		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+			new_storm_types2, new_dbzcomp_props2
+		)
+
+		new_storm_types = new_storm_types2.copy()
+		new_storm_embs = new_storm_embs2.copy()
+		new_dbzcomp_props = new_dbzcomp_props2.copy()
+		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+		new_storm_parent_labels = new_storm_parent_labels2.copy()
+		new_storm_depths = new_storm_depths2.copy()
+
+	if itr == max_itr and len(new_storm_depths)>0:
+
+		# If object embedded within QLCS_embedded object, discard the former
+		# If object embedded within AMORPHOUS or CELL is the only object embedded therein, discard it. If parent object is AMORPHOUS, reclassify it as discarded child object type.
+		# If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is unembedded, reclassify parent as CLUSTER or SUP_CLUSTER.
+		# If object embedded within AMORPHOUS or CELL is one of multiple such objects, and parent object is embedded in another object, remove parent since it we don't want embedded clusters
+
+		for depth in range(max(new_storm_depths), -1, -1):
+
+			if debug:
+				print("depth = %d" % depth)
+			remove_indices = []
+			parent_labels = []
+
+			for n, storm_type in enumerate(new_storm_types):
+
+				if new_storm_depths[n] == depth:  # and depth==2:
+
+					if new_storm_embs[n] in ["EMB-QLCS999"]:
+
+						parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+
+						for nn, storm2_region in enumerate(new_dbzcomp_props):
+
+							if new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area:
+
+								child_coords = np.asarray(storm2_region.coords)
+
+								if check_overlap(child_coords, parent_coords):
+
+									if nn not in remove_indices:
+										remove_indices.append(nn)
+										parent_labels.append(new_dbzcomp_props[n].label)
+										if debug:
+											print(
+												"Removing %s within %s within %s"
+												% (
+													new_storm_types[nn],
+													storm_type,
+													new_storm_embs[n][4:],
+												)
+											)
+
+					elif new_storm_embs[n] in ["EMB-CELL", "EMB-CLUS"]:
+
+						parent_label = new_storm_parent_labels[n]
+						const_indices = [n]
+
+						for nn in range(len(new_storm_types)):
+							if new_dbzcomp_props[nn].label == parent_label:
+								parent_index = nn
+								break
+
+						if new_storm_types[n] == "ROTATE":
+							num_sups = 1
+						else:
+							num_sups = 0
+
+						for nn in range(len(new_storm_types)):
+
+							if nn != n and new_storm_parent_labels[nn] == parent_label:
+
+								const_indices.append(nn)
+								if new_storm_types[nn] == "ROTATE":
+									num_sups += 1
+
+						if len(const_indices) == 1:
+							if n not in remove_indices:
+								remove_indices.append(n)
+								parent_labels.append(parent_label)
+								if new_storm_embs[n] == "EMB-CLUS":
+									new_storm_types2[parent_index] = storm_type
+								if debug:
+									print(
+										"Removing singleton %s from %s (which is now a %s)"
+										% (
+											storm_type,
+											new_storm_types[parent_index],
+											storm_type,
+										)
+									)
+
+						elif new_storm_embs[
+							parent_index
+						] == "NONEMB" and new_storm_types[parent_index] not in [
+							"CLUSTER",
+							"SUP_CLUST",
+						]:
+
+							if num_sups > 1:
+								if debug:
+									print(
+										"Converting parent %s to SUP_CLUST"
+										% new_storm_types2[parent_index]
+									)
+								new_storm_types2[parent_index] = "SUP_CLUST"
+							else:
+								if debug:
+									print(
+										"Converting parent %s to CLUSTER"
+										% new_storm_types2[parent_index]
+									)
+								new_storm_types2[parent_index] = "CLUSTER"
+							for ind in const_indices:
+								new_storm_embs2[ind] = "EMB-CLUS"
+
+						elif new_storm_embs[parent_index] != "NONEMB":
+
+							if parent_index not in remove_indices:
+								if debug:
+									print(
+										"Removing parent %s since it is actually an embedded cluster"
+										% new_storm_types[parent_index]
+									)
+								remove_indices.append(parent_index)
+								parent_labels.append(
+									new_storm_parent_labels[parent_index]
+								)
+								for ind in const_indices:
+									new_storm_embs2[ind] = "EMB-CLUS"
+
+			if len(remove_indices) != len(set(remove_indices)):
+				if debug:
+					print("DUPLICATES in remove_indices!!! Exiting.")
+					sys.exit(1)
+
+			for ind in sorted(remove_indices, reverse=True):
+				new_storm_types2.pop(ind)
+				new_storm_embs2.pop(ind)
+				new_dbzcomp_props2.pop(ind)
+				new_storm_parent_labels2.pop(ind)
+
+			(
+				new_storm_parent_labels2,
+				new_storm_embs2,
+				new_storm_depths2,
+			) = object_hierarchy(new_storm_types2, new_dbzcomp_props2)
+
+			new_storm_types = new_storm_types2.copy()
+			new_storm_embs = new_storm_embs2.copy()
+			new_dbzcomp_props = new_dbzcomp_props2.copy()
+			new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+			new_storm_parent_labels = new_storm_parent_labels2.copy()
+			new_storm_depths = new_storm_depths2.copy()
+
+	if itr == max_itr:
+
+		for n, storm_type in enumerate(new_storm_types):
+
+			if new_storm_types[n] == "CLUSTER":
+
+				num_sup = 0
+				parent_coords = np.asarray(new_dbzcomp_props[n].coords)
+
+				for nn, storm2_region in enumerate(new_dbzcomp_props):
+
+					if (
+						new_storm_types[nn] == "ROTATE"
+						and new_dbzcomp_props[nn].area < new_dbzcomp_props[n].area
+					):
+
+						child_coords = np.asarray(storm2_region.coords)
+
+						if check_overlap(child_coords, parent_coords):
+
+							num_sup += 1
+
+							if num_sup == 2:
+								new_storm_types[n] = "SUP_CLUST"
+								if debug:
+									print("CONVERTING CLUSTER TO SUP_CLUST!!! Exiting.")
+									sys.exit(1)
+								break
+
+		new_storm_parent_labels2, new_storm_embs2, new_storm_depths2 = object_hierarchy(
+			new_storm_types2, new_dbzcomp_props2
+		)
+
+		new_storm_types = new_storm_types2.copy()
+		new_storm_embs = new_storm_embs2.copy()
+		new_dbzcomp_props = new_dbzcomp_props2.copy()
+		new_dbzcomp_labels = new_dbzcomp_labels2.copy()
+		new_storm_parent_labels = new_storm_parent_labels2.copy()
+		new_storm_depths = new_storm_depths2.copy()
+
+	if itr == max_itr:
+
+		# Recast irregular discrete cell objects as AMORPHOUS
+
+		new_storm_types2 = list(new_storm_types)
+		new_storm_embs2 = list(new_storm_embs)
+		new_dbzcomp_props2 = list(new_dbzcomp_props)
+		new_dbzcomp_labels2 = new_dbzcomp_labels.copy()
+
+		for n, storm_type in enumerate(new_storm_types):
+
+			if (
+				storm_type in ["ROTATE", "NONROT"]
+				and new_storm_embs[n] == "NONEMB"
+				and (
+					new_dbzcomp_props[n].major_axis_length > 75 / 3.0
+					or new_dbzcomp_props[n].solidity < 0.7
+					or new_dbzcomp_props[n].eccentricity > 0.97
+				)
+			):
+
+				new_storm_types2[n] = "AMORPHOUS"
+				if debug:
+					print(
+						"Converting DISCRETE CELL to AMORPHOUS",
+						new_dbzcomp_props[n].area,
+						new_dbzcomp_props[n].major_axis_length,
+						new_dbzcomp_props[n].eccentricity,
+						new_dbzcomp_props[n].solidity,
+					)
+
+		new_storm_types = new_storm_types2
+		new_storm_embs = new_storm_embs2
+		new_dbzcomp_props = new_dbzcomp_props2
+		new_dbzcomp_labels = new_dbzcomp_labels2
+
+	if itr == max_itr:
+		return new_storm_types, new_storm_embs, new_dbzcomp_props, new_storm_depths2
+	else:
+		return new_storm_types, new_storm_embs, new_dbzcomp_props, None
+
+	return new_storm_types, new_storm_embs, new_dbzcomp_labels, new_dbzcomp_props
+  
+  
+@jit(fastmath=True) 
+def iterate_storm_types(storm_types, new_storm_types, new_dbzcomp_labels, 
+						dbz_coords,dbz_centroid,dbz_equiv_diam,dbz_area,
+						temp_storm_types, temp_coords,temp_prop_label,temp_dbzcomp_labels,
+						temp_centroid,temp_equiv_diam, temp_area, label_inc): 
+	
+	new_inds = []	
+	for n, storm_type in enumerate(storm_types):
+		
+		# Cycle through candidate storm objects
+
+		prelim_new_storm_types = []
+		prelim_new_dbzcomp_centroid = []
+		prelim_new_dbzcomp_equiv_diam= []
+		prelim_new_dbzcomp_area = []
+		prelim_temp_labels = []
+		temp_inds = []
+
+		parent_coords = dbz_coords[n]
+		
+		for nn, prop in enumerate(temp_prop_label):
+			child_coords = temp_coords[nn]
+			if temp_storm_types[nn] in ["ROTATE", "NONROT"]:
+				
+				if check_overlap(child_coords, parent_coords):
+					# If candidate storm object overlaps an existing storm object,
+					# retain and characterize it for further testing
+					prelim_new_storm_types.append(temp_storm_types[nn])
+					temp_prop_label[
+						nn
+					] += label_inc	# ensure new object has unique label so as not to combine with preexisting object
+					prelim_new_dbzcomp_centroid.append(temp_centroid[nn])
+					prelim_new_dbzcomp_area.append(temp_area[nn])
+					prelim_new_dbzcomp_equiv_diam.append(temp_equiv_diam[nn])
+					prelim_temp_labels.append(temp_prop_label[nn])
+					temp_inds.append(nn)
+
+		# cycle through each candidate new storm object
+		for nnn, new_storm_type in enumerate(prelim_new_storm_types):
+
+			# if storm object is a CELL, determine if this object is likely just a smaller 
+			# version of an existing object (versus a constituent of a larger storm)
+
+			if new_storm_type in ["ROTATE", "NONROT"]:
+
+				similar_storm_found = False
+
+				prelim_i = prelim_new_dbzcomp_centroid[nnn][0]
+				prelim_j = prelim_new_dbzcomp_centroid[nnn][1]
+
+				for nnnn, exist_props in enumerate(dbz_centroid):
+
+					if new_storm_types[nnnn] in ["ROTATE", "NONROT"]:  ### NEW
+
+						exist_i = exist_props[0]
+						exist_j = exist_props[1]
+						dist = sqrt(
+							pow(prelim_i - exist_i, 2) + pow(prelim_j - exist_j, 2)
+						)
+
+						if (
+							dist < max(2, 0.15 * dbz_equiv_diam[nnn])
+							and prelim_new_dbzcomp_area[nnn] <= 1.0 * dbz_area[nnnn]
+						):
+
+							similar_storm_found = True
+							break
+
+				# if candidate object is not merely a smaller version of an existing object, retain it
+
+				if not similar_storm_found:
+					new_storm_types.append(prelim_new_storm_types[nnn])
+					new_inds.append(temp_inds[nnn])
+					dbz_centroid.append(prelim_new_dbzcomp_centroid[nnn])
+					dbz_area.append(prelim_new_dbzcomp_area[nnn])
+					dbz_equiv_diam.append(prelim_new_dbzcomp_equiv_diam[nnn])
+					new_dbzcomp_labels = whereeq(new_dbzcomp_labels.astype(np.int64),temp_dbzcomp_labels.astype(np.int64),
+					np.int64(prelim_temp_labels[nnn] - label_inc),np.int64(prelim_temp_labels[nnn])).astype(np.int8)
+					
+	return new_storm_types,new_dbzcomp_labels,new_inds
+
+ 
 def get_storm_labels(storm_emb, storm_type):
 
-    convert_labels = {
-        "ROTATE": "SUPERCELL",
-        "NONROT": "ORDINARY",
-        "SEGMENT": "OTHER",
-        "QLCS": "QLCS",
-        "CLUSTER": "OTHER",
-        "AMORPHOUS": "OTHER",
-        "QLCS_ROT": "QLCS_MESO",
-        "QLCS_NON": "QLCS_ORD",
-        "CLUS_ROT": "SUPERCELL",
-        "CLUS_NON": "ORDINARY",
-        "SUP_CLUST": "SUP_CLUST",
-        "CELL_NON": "ORDINARY",
-        "CELL_ROT": "SUPERCELL",
-    }
-    digitize_types = {
-        key: n
-        for n, key in enumerate(
-            [
-                "ORDINARY",
-                "SUPERCELL",
-                "QLCS",
-                "SUP_CLUST",
-                "QLCS_ORD",
-                "QLCS_MESO",
-                "OTHER",
-            ]
-        )
-    }
+	convert_labels = {
+		"ROTATE": "SUPERCELL",
+		"NONROT": "ORDINARY",
+		"SEGMENT": "OTHER",
+		"QLCS": "QLCS",
+		"CLUSTER": "OTHER",
+		"AMORPHOUS": "OTHER",
+		"QLCS_ROT": "QLCS_MESO",
+		"QLCS_NON": "QLCS_ORD",
+		"CLUS_ROT": "SUPERCELL",
+		"CLUS_NON": "ORDINARY",
+		"SUP_CLUST": "SUP_CLUST",
+		"CELL_NON": "ORDINARY",
+		"CELL_ROT": "SUPERCELL",
+	}
+	digitize_types = {
+		key: n
+		for n, key in enumerate(
+			[
+				"ORDINARY",
+				"SUPERCELL",
+				"QLCS",
+				"SUP_CLUST",
+				"QLCS_ORD",
+				"QLCS_MESO",
+				"OTHER",
+			]
+		)
+	}
 
-    if storm_emb == "NONEMB":
-        label = storm_type
-    else:
-        label = "%s_%s" % (storm_emb[4:], storm_type[:3])
+	if storm_emb == "NONEMB":
+		label = storm_type
+	else:
+		label = "%s_%s" % (storm_emb[4:], storm_type[:3])
 
-    type_str = convert_labels[label]
-    type_int = int(digitize_types[type_str])
+	type_str = convert_labels[label]
+	type_int = int(digitize_types[type_str])
 
-    return type_int, type_str
+	return type_int, type_str
 
 
 def get_storm_types(
-    model,
-    qc_dbzcomp_labels,
-    qc_dbzcomp_props,
-    dbzcomp,
-    qc_uh_labels,
-    qc_uh_props,
-    uh,
-    ANALYSIS_DX, 
-    last_iter=False,
+	model,
+	qc_dbzcomp_labels,
+	qc_dbzcomp_props,
+	dbzcomp,
+	qc_uh_labels,
+	qc_uh_props,
+	uh,
+	ANALYSIS_DX, 
+	last_iter=False,
 ):
-    """
-    # PURPOSE:
+	"""
+	# PURPOSE:
 
-    # Classify storm objects based on REFLCOMP and UH5000/AZSHR fields
+	# Classify storm objects based on REFLCOMP and UH5000/AZSHR fields
 
-    # INPUTS:
+	# INPUTS:
 
-    # model (str), date (str), lead_time (int; mins) for which qc_dbzcomp_labels, etc. are valid
+	# model (str), date (str), lead_time (int; mins) for which qc_dbzcomp_labels, etc. are valid
 
-    # qc_dbzcomp_labels: single QC'd REFLCOMP 2-D label numpy array
-    # qc_dbzcomp_props: regionprops for each label in qc_dbzcomp_labels
-    # dbzcomp: 2-D REFLCOMP field from which qc_dbzcomp_labels, qc_dbzcomp_props generated
+	# qc_dbzcomp_labels: single QC'd REFLCOMP 2-D label numpy array
+	# qc_dbzcomp_props: regionprops for each label in qc_dbzcomp_labels
+	# dbzcomp: 2-D REFLCOMP field from which qc_dbzcomp_labels, qc_dbzcomp_props generated
 
-    # uh_labels/qc_uh_props/uh: as with qc_dbzcomp_labels/qc_dbzcomp_props/dbzcomp
+	# uh_labels/qc_uh_props/uh: as with qc_dbzcomp_labels/qc_dbzcomp_props/dbzcomp
 
-    # RETURNS:
+	# RETURNS:
 
-    # List of storm types (one for each regionprops in qc_dbzcomp_props, i.e., one for each REFLCOMP object)
+	# List of storm types (one for each regionprops in qc_dbzcomp_props, i.e., one for each REFLCOMP object)
 
-    # Author: Corey Potvin
-    """
-    
-    storm_types = []
-    labels_with_matched_rotation = []
-    all_uh_coords = []
+	# Author: Corey Potvin
+	"""
+	
+	storm_types = []
+	labels_with_matched_rotation = []
+	all_uh_coords = []
 
-    # Concatenate all coordinates of strong rotation, then identify regions with proximate rotation objects
+	# Concatenate all coordinates of strong rotation, then identify regions with proximate rotation objects
 
-    for n, qc_uh_prop in enumerate(qc_uh_props):
-        for coord in qc_uh_prop.coords:
-            all_uh_coords.append(coord)
-    all_uh_coords = np.asarray(all_uh_coords)
+	for n, qc_uh_prop in enumerate(qc_uh_props):
+		for coord in qc_uh_prop.coords:
+			all_uh_coords.append(coord)
+	all_uh_coords = np.asarray(all_uh_coords)
 
-    if len(all_uh_coords) > 0:
-        for qc_dbzcomp_prop in qc_dbzcomp_props:
-            ic, jc = int(qc_dbzcomp_prop.centroid[0]), int(qc_dbzcomp_prop.centroid[1])
-            rad = max(2, ceil(qc_dbzcomp_prop.equivalent_diameter / 3.0))
-            imin, imax = ic - rad, ic + rad
-            jmin, jmax = jc - rad, jc + rad
-            dbz_coords = []
-            for i in range(imin, imax + 1):
-                for j in range(jmin, jmax + 1):
-                    dbz_coords.append([i, j])
-            dbz_coords = np.asarray(dbz_coords)
-            if check_overlap(dbz_coords, all_uh_coords):
-                labels_with_matched_rotation.append(qc_dbzcomp_prop.label)
+	if len(all_uh_coords) > 0:
+		for qc_dbzcomp_prop in qc_dbzcomp_props:
+			ic, jc = int(qc_dbzcomp_prop.centroid[0]), int(qc_dbzcomp_prop.centroid[1])
+			rad = max(2, ceil(qc_dbzcomp_prop.equivalent_diameter / 3.0))
+			imin, imax = ic - rad, ic + rad
+			jmin, jmax = jc - rad, jc + rad
+			dbz_coords = []
+			for i in range(imin, imax + 1):
+				for j in range(jmin, jmax + 1):
+					dbz_coords.append([i, j])
+			dbz_coords = np.asarray(dbz_coords)
+			if check_overlap(dbz_coords, all_uh_coords):
+				labels_with_matched_rotation.append(qc_dbzcomp_prop.label)
 
-    for n, region in enumerate(qc_dbzcomp_props):
+	for n, region in enumerate(qc_dbzcomp_props):
 
-        # see scikit-image regionprops documentation for definitions of object attributes
+		# see scikit-image regionprops documentation for definitions of object attributes
 
-        DBZ_length = region.major_axis_length * ANALYSIS_DX
-        DBZ_area = region.area * pow(ANALYSIS_DX, 2)
+		DBZ_length = region.major_axis_length * ANALYSIS_DX
+		DBZ_area = region.area * pow(ANALYSIS_DX, 2)
 
-        if DBZ_area < 100e6 or (
-            DBZ_area < 200e6 and region.eccentricity < 0.7 and region.solidity > 0.7
-        ):
+		if DBZ_area < 100e6 or (
+			DBZ_area < 200e6 and region.eccentricity < 0.7 and region.solidity > 0.7
+		):
 
-            if region.label in labels_with_matched_rotation:
-                storm_type = "ROTATE"
-            else:
-                storm_type = "NONROT"
+			if region.label in labels_with_matched_rotation:
+				storm_type = "ROTATE"
+			else:
+				storm_type = "NONROT"
 
-        elif region.eccentricity > 0.97:
+		elif region.eccentricity > 0.97:
 
-            if DBZ_length > 75e3:
-                storm_type = "QLCS"
-            else:
-                storm_type = "AMORPHOUS"
+			if DBZ_length > 75e3:
+				storm_type = "QLCS"
+			else:
+				storm_type = "AMORPHOUS"
 
-        elif region.eccentricity > 0.9 and DBZ_length > 150e3:
-            storm_type = "QLCS"
+		elif region.eccentricity > 0.9 and DBZ_length > 150e3:
+			storm_type = "QLCS"
 
-        elif (
-            region.eccentricity > 0.93
-            or DBZ_area > 500e6
-            or DBZ_length > 75e3
-            or region.solidity < 0.7
-        ):
-            storm_type = "AMORPHOUS"
+		elif (
+			region.eccentricity > 0.93
+			or DBZ_area > 500e6
+			or DBZ_length > 75e3
+			or region.solidity < 0.7
+		):
+			storm_type = "AMORPHOUS"
 
-        elif region.label in labels_with_matched_rotation:
-            storm_type = "ROTATE"
+		elif region.label in labels_with_matched_rotation:
+			storm_type = "ROTATE"
 
-        else:
-            storm_type = "NONROT"
+		else:
+			storm_type = "NONROT"
 
-        # if storm_type in ['ROTATE', 'NONROT'] and (DBZ_length > 75e3 or region.solidity < 0.7 or region.eccentricity > 0.97):
-        #  storm_type = 'AMORPHOUS'
+		# if storm_type in ['ROTATE', 'NONROT'] and (DBZ_length > 75e3 or region.solidity < 0.7 or region.eccentricity > 0.97):
+		#  storm_type = 'AMORPHOUS'
 
-        storm_types.append(storm_type)
+		storm_types.append(storm_type)
 
-    return storm_types, labels_with_matched_rotation
+	return storm_types, labels_with_matched_rotation
 
-
+@jit
 def check_overlap(coords1, coords2):
 
-    for item1 in coords1:
-        for item2 in coords2:
-            if (item1 == item2).all():
-                return True
+	for item1 in coords1:
+		for item2 in coords2:
+			if (item1 == item2).all():
+				return True
 
-    return False
+	return False
 
 
 def object_hierarchy(storm_types, dbzcomp_props):
 
-    storm_parent_labels = list(np.zeros(len(storm_types)))
-    storm_embs = list(np.zeros(len(storm_types)))
+	storm_parent_labels = list(np.zeros(len(storm_types)))
+	storm_embs = list(np.zeros(len(storm_types)))
 
-    for n, storm_type in enumerate(storm_types):
+	for n, storm_type in enumerate(storm_types):
 
-        child_coords = np.asarray(dbzcomp_props[n].coords)
-        min_potential_parent_area = 9999999999
-        parent_found = False
+		child_coords = np.asarray(dbzcomp_props[n].coords)
+		min_potential_parent_area = 9999999999
+		parent_found = False
 
-        for nn in range(len(dbzcomp_props)):
-            potential_parent_area = dbzcomp_props[nn].area
-            if potential_parent_area > dbzcomp_props[n].area:
-                potential_parent_coords = np.asarray(dbzcomp_props[nn].coords)
-                if check_overlap(child_coords, potential_parent_coords):
-                    parent_found = True
-                    if potential_parent_area < min_potential_parent_area:
-                        min_potential_parent_area = potential_parent_area
-                        potential_parent_index = nn
+		for nn in range(len(dbzcomp_props)):
+			potential_parent_area = dbzcomp_props[nn].area
+			if potential_parent_area > dbzcomp_props[n].area:
+				potential_parent_coords = np.asarray(dbzcomp_props[nn].coords)
+				if check_overlap(child_coords, potential_parent_coords):
+					parent_found = True
+					if potential_parent_area < min_potential_parent_area:
+						min_potential_parent_area = potential_parent_area
+						potential_parent_index = nn
 
-        if parent_found:
-            storm_parent_labels[n] = dbzcomp_props[potential_parent_index].label
-            if storm_types[potential_parent_index] == "QLCS":
-                storm_embs[n] = "EMB-QLCS"
-            elif storm_types[potential_parent_index] in [
-                "CLUSTER",
-                "AMORPHOUS",
-                "SUP_CLUST",
-            ]:
-                storm_embs[n] = "EMB-CLUS"
-            else:
-                storm_embs[n] = "EMB-CELL"
-        else:
-            storm_embs[n] = "NONEMB"
+		if parent_found:
+			storm_parent_labels[n] = dbzcomp_props[potential_parent_index].label
+			if storm_types[potential_parent_index] == "QLCS":
+				storm_embs[n] = "EMB-QLCS"
+			elif storm_types[potential_parent_index] in [
+				"CLUSTER",
+				"AMORPHOUS",
+				"SUP_CLUST",
+			]:
+				storm_embs[n] = "EMB-CLUS"
+			else:
+				storm_embs[n] = "EMB-CELL"
+		else:
+			storm_embs[n] = "NONEMB"
 
-        storm_labels = [props.label for props in dbzcomp_props]
+		storm_labels = [props.label for props in dbzcomp_props]
 
-    storm_depths = []
+	storm_depths = []
 
-    for n in range(len(storm_parent_labels)):
+	for n in range(len(storm_parent_labels)):
 
-        depth = 0
-        nn = n
+		depth = 0
+		nn = n
 
-        while storm_parent_labels[nn] > 0:
+		while storm_parent_labels[nn] > 0:
 
-            depth += 1
-            parent_label = storm_parent_labels[nn]
-            nn = storm_labels.index(parent_label)
+			depth += 1
+			parent_label = storm_parent_labels[nn]
+			nn = storm_labels.index(parent_label)
 
-        storm_depths.append(depth)
-        # print (n, storm_types[n], depth)
+		storm_depths.append(depth)
+		# print (n, storm_types[n], depth)
 
-    return storm_parent_labels, storm_embs, storm_depths
+	return storm_parent_labels, storm_embs, storm_depths

--- a/monte_python/object_quality_control.py
+++ b/monte_python/object_quality_control.py
@@ -4,7 +4,7 @@ import skimage.measure
 from math import sqrt
 from collections import OrderedDict
 from skimage.measure import regionprops 
-from numba import jit, typeof
+from numba import jit
 from numba_kdtree import KDTree
 #import warnings
 #warnings.simplefilter("ignore", UserWarning)

--- a/monte_python/object_quality_control.py
+++ b/monte_python/object_quality_control.py
@@ -4,216 +4,237 @@ import skimage.measure
 from math import sqrt
 from collections import OrderedDict
 from skimage.measure import regionprops 
+from numba import jit, typeof
+from numba_kdtree import KDTree
 #import warnings
 #warnings.simplefilter("ignore", UserWarning)
 
+@jit(fastmath=True, parallel=True)	
+def loop_label_merge(region_tree,original_labels,remaining_labels, label,
+					qc_object_labels, merge_thresh):
+	for other_label in original_labels:
+		if other_label != label and other_label in remaining_labels: 
+			y_idx, x_idx = np.where( qc_object_labels == other_label)
+			xrav = x_idx.ravel()
+			yrav = y_idx.ravel()
+			other_label_xy_stack = np.dstack((xrav,yrav))[0]
+			dist_btw_objects, _ = region_tree.query(other_label_xy_stack)
+			if round(np.amin(dist_btw_objects), 2) <= merge_thresh: 
+				qc_object_labels = whereeq(qc_object_labels, qc_object_labels, other_label, label)
+				remaining_labels = np.unique(qc_object_labels)[1:]
+						
+	return qc_object_labels, remaining_labels
+
+
+@jit(fastmath=True,parallel=True) 
+def whereeq(arr,arrind,val,setval):
+	for i in np.arange(arr.shape[0]):
+		for j in np.arange(arr.shape[1]):
+			if arrind[i,j]==val:
+				arr[i,j] = setval
+	return arr
+
 class QualityControler:
-    '''
-    QualityControl implements multiple quality control measures to post-process identified objects.
-    These include: 
-        - Minimum Area
-        - Merging
-        - Maximum Length
-        - Duration
-        - Maximum Value Within
-        - Matched to Local Storm Reports
-    '''
-    qc_to_module_dict = {'min_area' : '_remove_small_objects', 
-                         'merge_thresh' : '_merge', 
-                         'max_length' : '_remove_long_objects',
-                         'min_time' : '_remove_short_duration_objects',
-                         'max_thresh' : '_remove_low_intensity_objects',
-                         'match_to_lsr' : '_remove_objects_unmatched_to_lsrs'
-                        }
-    
-    def __call__(self, input_data, object_labels, object_properties, qc_params):
-        return self.quality_control(input_data, object_labels, object_properties, qc_params)
-        
-        
-    def quality_control(self, input_data, object_labels, object_properties, qc_params): 
-        """
-        Applies quality control to identified objects. 
-        Parameters:
-        -------------------------
-            object_labels, 2D numpy array of labeled objects
-            
-            object_properties, object properties calculated by skimage.measure.regionprops for object labels
-            
-            input_data, original 2D numpy array of data from which object_labels was generated from
-            
-            qc_params,  List of tuples or ordered dictionary of the quality control option to apply 
-                          and the corresponding criteria. E.g., to apply a minimum area threshold 
-                          qc_params = [('min_area', 10)]. 
-                Potential quality control
-                 - 'min_area', removing objects below the minimum area (in number of pixels)
-                 - 'merge_thresh', merging objects together closer than a minimum distance (in gridpoints)
-                 - 'max_length', removing objects with a major axis length greater the given criterion (in gridpoints)
-                 - 'min_time', removing objects with duration less than the given criterion (in time steps) 
-                 - 'max_thresh', removing objects if the Pth percentile value is less than the given value. 
-                                 For max, P=100 and min, P=0. For this quality control, use a nested tuple
-                                 E.g., qc_params = [('max_thresh', (value, P)]
-                 - 'match_to_lsr', remove objects not matched to an local storm report
-                For additional details, read the functions below. 
+	'''
+	QualityControl implements multiple quality control measures to post-process identified objects.
+	These include: 
+		- Minimum Area
+		- Merging
+		- Maximum Length
+		- Duration
+		- Maximum Value Within
+		- Matched to Local Storm Reports
+	'''
+	qc_to_module_dict = {'min_area' : '_remove_small_objects', 
+						 'merge_thresh' : '_merge', 
+						 'max_length' : '_remove_long_objects',
+						 'min_time' : '_remove_short_duration_objects',
+						 'max_thresh' : '_remove_low_intensity_objects',
+						 'match_to_lsr' : '_remove_objects_unmatched_to_lsrs'
+						}
+	
+	def __call__(self, input_data, object_labels, object_properties, qc_params):
+		return self.quality_control(input_data, object_labels, object_properties, qc_params)
+		
+		
+	def quality_control(self, input_data, object_labels, object_properties, qc_params): 
+		"""
+		Applies quality control to identified objects. 
+		Parameters:
+		-------------------------
+			object_labels, 2D numpy array of labeled objects
+			
+			object_properties, object properties calculated by skimage.measure.regionprops for object labels
+			
+			input_data, original 2D numpy array of data from which object_labels was generated from
+			
+			qc_params,	List of tuples or ordered dictionary of the quality control option to apply 
+						  and the corresponding criteria. E.g., to apply a minimum area threshold 
+						  qc_params = [('min_area', 10)]. 
+				Potential quality control
+				 - 'min_area', removing objects below the minimum area (in number of pixels)
+				 - 'merge_thresh', merging objects together closer than a minimum distance (in gridpoints)
+				 - 'max_length', removing objects with a major axis length greater the given criterion (in gridpoints)
+				 - 'min_time', removing objects with duration less than the given criterion (in time steps) 
+				 - 'max_thresh', removing objects if the Pth percentile value is less than the given value. 
+								 For max, P=100 and min, P=0. For this quality control, use a nested tuple
+								 E.g., qc_params = [('max_thresh', (value, P)]
+				 - 'match_to_lsr', remove objects not matched to an local storm report
+				For additional details, read the functions below. 
  
-        Returns:
-        -------------------------
-            2-tuple of (object_labels, object_props) 
-            object_labels, quality-controlled version of the original object_labels
-            object_props, object properties of the quality-controlled objects
-        """
-        self.input_data = input_data
-        self.object_labels = object_labels
-        self.object_properties = object_properties
-        
-        if isinstance(qc_params, list):
-            qc_params = OrderedDict(qc_params)
-        self.qc_params = qc_params
-        
-        for qc_method in self.qc_params.keys():
-            getattr(self, self.qc_to_module_dict[qc_method])()
-            
-        return (self.object_labels, self.object_properties) 
+		Returns:
+		-------------------------
+			2-tuple of (object_labels, object_props) 
+			object_labels, quality-controlled version of the original object_labels
+			object_props, object properties of the quality-controlled objects
+		"""
+		self.input_data = input_data
+		self.object_labels = object_labels
+		self.object_properties = object_properties
+		
+		if isinstance(qc_params, list):
+			qc_params = OrderedDict(qc_params)
+		self.qc_params = qc_params
+		
+		for qc_method in self.qc_params.keys():
+			getattr(self, self.qc_to_module_dict[qc_method])()
+			
+		return (self.object_labels, self.object_properties) 
 
-    def _remove_small_objects(self):
-        ''' 
-        Removes objects with area less than min_area. Area measured by the number of
-        grid cells.
-        Args,
-            : input_data, 2D numpy array, original data from which the object labels were generated from.
-                                          Used to recalculate the regionprops after qualtiy control is applied. 
-            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-            : min_area, int, minimum area (in number of grid points) of an object
-        '''
-        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8) 
-        j=1
-        for region in self.object_properties:
-            if region.area >= self.qc_params['min_area']:
-                qc_object_labels[self.object_labels == region.label] = j 
-                j+=1     
-        qc_object_properties = regionprops( qc_object_labels, self.input_data,  ) 
-        
-        self.object_labels = qc_object_labels
-        self.object_properties = qc_object_properties
+	def _remove_small_objects(self):
+		''' 
+		Removes objects with area less than min_area. Area measured by the number of
+		grid cells.
+		Args,
+			: input_data, 2D numpy array, original data from which the object labels were generated from.
+										  Used to recalculate the regionprops after qualtiy control is applied. 
+			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+			: min_area, int, minimum area (in number of grid points) of an object
+		'''
+		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8) 
+		j = 1
+		for region in self.object_properties:
+			 if region.area >= self.qc_params['min_area']:
+				 qc_object_labels[self.object_labels == region.label] = j 
+				 j+=1
+		qc_object_properties = regionprops( qc_object_labels, self.input_data,	) 
+		
+		self.object_labels = qc_object_labels
+		self.object_properties = qc_object_properties
 
-    def _remove_long_objects(self):
-        ''' 
-        Removes objects with a major axis length greater than max_length 
-        Args,
-            : input_data, 2D numpy array, original data from which the object labels were generated from.
-                                          Used to recalculate the regionprops after qualtiy control is applied. 
-            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-            : max_length, int, maximum object length (in grid point distances) 
-        '''
-        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-        j=1
-        for region in self.object_properties:
-            if round(region.major_axis_length, 2) >= self.qc_params['max_length']:
-                qc_object_labels[self.object_labels == region.label] = j
-                j+=1
-        qc_object_properties = regionprops( qc_object_labels, self.input_data,  )
+	def _remove_long_objects(self):
+		''' 
+		Removes objects with a major axis length greater than max_length 
+		Args,
+			: input_data, 2D numpy array, original data from which the object labels were generated from.
+										  Used to recalculate the regionprops after qualtiy control is applied. 
+			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+			: max_length, int, maximum object length (in grid point distances) 
+		'''
+		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+		j=1
+		for region in self.object_properties:
+			 if round(region.major_axis_length, 2) >= self.qc_params['max_length']:
+				 qc_object_labels[self.object_labels == region.label] = j
+				 j+=1
+		qc_object_properties = regionprops( qc_object_labels, self.input_data,	)
 
-        self.object_labels = qc_object_labels
-        self.object_properties = qc_object_properties
+		self.object_labels = qc_object_labels
+		self.object_properties = qc_object_properties
 
-    def _remove_low_intensity_objects(self):
-        ''' 
-        Removes objects where the 75th percentile intensity is below the max_thresh
-        Args,
-            : input_data, 2D numpy array, original data from which the object labels were generated from.
-                                          Used to recalculate the regionprops after qualtiy control is applied. 
-            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-            : max_thresh, float, intensity threshold for the 75th percentile
-        '''
-        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-        j=1
-        val, P = self.qc_params['max_thresh']
-        for region in self.object_properties: 
-            if round( np.percentile(self.input_data[self.object_labels == region.label], P), 10) \
-                >= round(val,10): 
-                qc_object_labels[self.object_labels == region.label] = j
-                j+=1
-        qc_object_properties = regionprops( qc_object_labels, self.input_data, )
+	def _remove_low_intensity_objects(self):
+		''' 
+		Removes objects where the 75th percentile intensity is below the max_thresh
+		Args,
+			: input_data, 2D numpy array, original data from which the object labels were generated from.
+										  Used to recalculate the regionprops after qualtiy control is applied. 
+			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+			: max_thresh, float, intensity threshold for the 75th percentile
+		'''
+		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+		j=1
+		val, P = self.qc_params['max_thresh']
+		for region in self.object_properties: 
+			 if round( np.percentile(self.input_data[self.object_labels == region.label], P), 10) \
+				 >= round(val,10): 
+				 qc_object_labels[self.object_labels == region.label] = j
+				 j+=1
+		
+		qc_object_properties = regionprops( qc_object_labels, self.input_data, )
 
-        self.object_labels = qc_object_labels
-        self.object_properties = qc_object_properties 
+		self.object_labels = qc_object_labels
+		self.object_properties = qc_object_properties 
 
-    def _remove_short_duration_objects(self): 
-        ''' 
-        When identify objects over a time duration, removes objects existing for a duration less than min_time
-        Args,
-            : input_data, 2D numpy array, original data from which the object labels were generated from.
-                                          Used to recalculate the regionprops after qualtiy control is applied. 
-            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-            : min_time, int, minimum duration (in terms of number of time steps) 
-            : time_argmax_idxs, When applying np.argmax over time dimensions of an array
-        '''
-        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-        j=1
-        time_argmax_idxs = self.qc_params['min_time'][1]
-        for region in self.object_properties:    
-            duration = len( np.unique( time_argmax_idxs[self.object_labels == region.label] ))  
-            if duration >= self.qc_params['min_time'][0]:
-                qc_object_labels[self.object_labels == region.label] = j
-                j+=1
-        qc_object_properties = regionprops( qc_object_labels, self.input_data, )        
-        
-        self.object_labels = qc_object_labels
-        self.object_properties = qc_object_properties
+	def _remove_short_duration_objects(self): 
+		''' 
+		When identify objects over a time duration, removes objects existing for a duration less than min_time
+		Args,
+			: input_data, 2D numpy array, original data from which the object labels were generated from.
+										  Used to recalculate the regionprops after qualtiy control is applied. 
+			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+			: min_time, int, minimum duration (in terms of number of time steps) 
+			: time_argmax_idxs, When applying np.argmax over time dimensions of an array
+		'''
+		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+		j=1
+		time_argmax_idxs = self.qc_params['min_time'][1]
+		for region in self.object_properties:	  
+			 duration = len( np.unique( time_argmax_idxs[self.object_labels == region.label] ))	 
+			 if duration >= self.qc_params['min_time'][0]:
+				 qc_object_labels[self.object_labels == region.label] = j
+				 j+=1
 
-    def _merge(self):
-        ''' 
-        Merges near-by objects to limit discontinuous objects from counting as multiple objects.
-        Applicable when using the single threshold object identification method. 
-        Args,
-            : input_data, 2D numpy array, original data from which the object labels were generated from.
-                                          Used to recalculate the regionprops after qualtiy control is applied. 
-            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-            : merge_thresh, float, merging distance (objects closer than the merging distance 
-                                   are combined together; in grid point distance)
-        '''
-        qc_object_labels = np.copy( self.object_labels ) 
-        original_labels = np.unique(qc_object_labels)[1:] #[label for label in np.unique(qc_object_labels)[1:]]
-        remaining_labels = np.unique(qc_object_labels)[1:]  #[label for label in np.unique(qc_object_labels)[1:]]
-        for label in original_labels:
-            # Does 'label' still exist? 
-            if int(label) in remaining_labels:
-                y_idx, x_idx = np.where( qc_object_labels == label )
-                label_xy_stack = np.dstack([x_idx.ravel(), y_idx.ravel()])[0]
-                region_tree = scipy.spatial.cKDTree( label_xy_stack )
-                for other_label in original_labels:
-                    # Does 'other_label' still exist?
-                    if other_label != label and int(other_label) in remaining_labels: 
-                        y_idx, x_idx = np.where( qc_object_labels == other_label )
-                        other_label_xy_stack = np.dstack([x_idx.ravel(), y_idx.ravel()])[0]
-                        dist_btw_objects, _ = region_tree.query(other_label_xy_stack)
-                        if round(np.amin(dist_btw_objects), 2) <= self.qc_params['merge_thresh']: 
-                            qc_object_labels[qc_object_labels == other_label] = label
-                            y_idx, x_idx = np.where( qc_object_labels == label )
-                            xy_stack = np.dstack([x_idx.ravel(), y_idx.ravel()])[0]
-                            region_tree = scipy.spatial.cKDTree( xy_stack )
-                            remaining_labels = np.unique(qc_object_labels)[1:]
-                            
-        remaining_labels = np.unique(qc_object_labels)[1:]
-        for i, label in enumerate(remaining_labels):
-            qc_object_labels[qc_object_labels==label] = int(i+1) 
+		qc_object_properties = regionprops( qc_object_labels, self.input_data, )		
+		
+		self.object_labels = qc_object_labels
+		self.object_properties = qc_object_properties
 
-        qc_object_properties = regionprops( qc_object_labels, self.input_data, )
-        self.object_labels = qc_object_labels
-        self.object_properties = qc_object_properties
+	def _merge(self):
+		''' 
+		Merges near-by objects to limit discontinuous objects from counting as multiple objects.
+		Applicable when using the single threshold object identification method. 
+		Args,
+			: input_data, 2D numpy array, original data from which the object labels were generated from.
+										  Used to recalculate the regionprops after qualtiy control is applied. 
+			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+			: merge_thresh, float, merging distance (objects closer than the merging distance 
+								   are combined together; in grid point distance)
+		'''
+		qc_object_labels = np.copy( self.object_labels ) 
+		original_labels = np.unique(qc_object_labels)[1:] #[label for label in np.unique(qc_object_labels)[1:]]
+		remaining_labels = np.unique(qc_object_labels)[1:]	#[label for label in np.unique(qc_object_labels)[1:]]
+		for label in original_labels:
+			# Does 'label' still exist? 
+			if int(label) in remaining_labels:
+				y_idx, x_idx = np.where( qc_object_labels == label )
+				label_xy_stack = np.dstack([x_idx.ravel(), y_idx.ravel()])[0]
+				region_tree = KDTree( label_xy_stack )
+				qc_object_labels, remaining_labels = loop_label_merge(
+				region_tree,original_labels.astype(np.int64), remaining_labels.astype(np.int64), np.int64(label), 
+				qc_object_labels.astype(np.int64), np.int64(self.qc_params['merge_thresh'])
+				)
+							
+		remaining_labels = np.unique(qc_object_labels)[1:]
+		for i, label in enumerate(remaining_labels):
+			qc_object_labels[qc_object_labels==label] = int(i+1) 
 
-    def _remove_objects_unmatched_to_lsrs(self):
-        '''
-        Removes objects unmatched to Local Storm Reports (LSRs).
-        '''
-        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-        j=1
-        for region in self.object_properties:
-            kdbelled_points, labelled_datatree = spatial.cKDTree( region.coords )
-            dist_btw_region_and_lsr, _ = kdtree.query( self.qc_params['match_to_lsr']['lsr_points'] )
-            if round( np.amin( dist_btw_region_and_lsr ), 10) < self.qc_params['match_to_lsr']['dist_to_lsr']:
-                qc_object_labels[self.object_labels == region.label] = j
-                j+=1
-            
-        qc_object_properties = regionprops( qc_object_labels, self.input_data, )
-        self.object_labels = qc_object_labels
-        self.object_properties = qc_object_properties
+		qc_object_properties = regionprops( qc_object_labels, self.input_data, )
+		self.object_labels = qc_object_labels
+		self.object_properties = qc_object_properties
+
+	def _remove_objects_unmatched_to_lsrs(self):
+		'''
+		Removes objects unmatched to Local Storm Reports (LSRs).
+		'''
+		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+		j=1
+		for region in self.object_properties:
+			kdbelled_points, labelled_datatree = spatial.cKDTree( region.coords )
+			dist_btw_region_and_lsr, _ = kdtree.query( self.qc_params['match_to_lsr']['lsr_points'] )
+			if round( np.amin( dist_btw_region_and_lsr ), 10) < self.qc_params['match_to_lsr']['dist_to_lsr']:
+				qc_object_labels[self.object_labels == region.label] = j
+				j+=1
+			
+		qc_object_properties = regionprops( qc_object_labels, self.input_data, )
+		self.object_labels = qc_object_labels
+		self.object_properties = qc_object_properties

--- a/monte_python/object_quality_control.py
+++ b/monte_python/object_quality_control.py
@@ -9,232 +9,232 @@ from numba_kdtree import KDTree
 #import warnings
 #warnings.simplefilter("ignore", UserWarning)
 
-@jit(fastmath=True, parallel=True)	
+@jit(fastmath=True, parallel=True)  
 def loop_label_merge(region_tree,original_labels,remaining_labels, label,
-					qc_object_labels, merge_thresh):
-	for other_label in original_labels:
-		if other_label != label and other_label in remaining_labels: 
-			y_idx, x_idx = np.where( qc_object_labels == other_label)
-			xrav = x_idx.ravel()
-			yrav = y_idx.ravel()
-			other_label_xy_stack = np.dstack((xrav,yrav))[0]
-			dist_btw_objects, _ = region_tree.query(other_label_xy_stack)
-			if round(np.amin(dist_btw_objects), 2) <= merge_thresh: 
-				qc_object_labels = whereeq(qc_object_labels, qc_object_labels, other_label, label)
-				remaining_labels = np.unique(qc_object_labels)[1:]
-						
-	return qc_object_labels, remaining_labels
+                    qc_object_labels, merge_thresh):
+    for other_label in original_labels:
+        if other_label != label and other_label in remaining_labels: 
+            y_idx, x_idx = np.where( qc_object_labels == other_label)
+            xrav = x_idx.ravel()
+            yrav = y_idx.ravel()
+            other_label_xy_stack = np.dstack((xrav,yrav))[0]
+            dist_btw_objects, _ = region_tree.query(other_label_xy_stack)
+            if round(np.amin(dist_btw_objects), 2) <= merge_thresh: 
+                qc_object_labels = whereeq(qc_object_labels, qc_object_labels, other_label, label)
+                remaining_labels = np.unique(qc_object_labels)[1:]
+                        
+    return qc_object_labels, remaining_labels
 
 
 @jit(fastmath=True,parallel=True) 
 def whereeq(arr,arrind,val,setval):
-	for i in np.arange(arr.shape[0]):
-		for j in np.arange(arr.shape[1]):
-			if arrind[i,j]==val:
-				arr[i,j] = setval
-	return arr
+    for i in np.arange(arr.shape[0]):
+        for j in np.arange(arr.shape[1]):
+            if arrind[i,j]==val:
+                arr[i,j] = setval
+    return arr
 
 class QualityControler:
-	'''
-	QualityControl implements multiple quality control measures to post-process identified objects.
-	These include: 
-		- Minimum Area
-		- Merging
-		- Maximum Length
-		- Duration
-		- Maximum Value Within
-		- Matched to Local Storm Reports
-	'''
-	qc_to_module_dict = {'min_area' : '_remove_small_objects', 
-						 'merge_thresh' : '_merge', 
-						 'max_length' : '_remove_long_objects',
-						 'min_time' : '_remove_short_duration_objects',
-						 'max_thresh' : '_remove_low_intensity_objects',
-						 'match_to_lsr' : '_remove_objects_unmatched_to_lsrs'
-						}
-	
-	def __call__(self, input_data, object_labels, object_properties, qc_params):
-		return self.quality_control(input_data, object_labels, object_properties, qc_params)
-		
-		
-	def quality_control(self, input_data, object_labels, object_properties, qc_params): 
-		"""
-		Applies quality control to identified objects. 
-		Parameters:
-		-------------------------
-			object_labels, 2D numpy array of labeled objects
-			
-			object_properties, object properties calculated by skimage.measure.regionprops for object labels
-			
-			input_data, original 2D numpy array of data from which object_labels was generated from
-			
-			qc_params,	List of tuples or ordered dictionary of the quality control option to apply 
-						  and the corresponding criteria. E.g., to apply a minimum area threshold 
-						  qc_params = [('min_area', 10)]. 
-				Potential quality control
-				 - 'min_area', removing objects below the minimum area (in number of pixels)
-				 - 'merge_thresh', merging objects together closer than a minimum distance (in gridpoints)
-				 - 'max_length', removing objects with a major axis length greater the given criterion (in gridpoints)
-				 - 'min_time', removing objects with duration less than the given criterion (in time steps) 
-				 - 'max_thresh', removing objects if the Pth percentile value is less than the given value. 
-								 For max, P=100 and min, P=0. For this quality control, use a nested tuple
-								 E.g., qc_params = [('max_thresh', (value, P)]
-				 - 'match_to_lsr', remove objects not matched to an local storm report
-				For additional details, read the functions below. 
+    '''
+    QualityControl implements multiple quality control measures to post-process identified objects.
+    These include: 
+        - Minimum Area
+        - Merging
+        - Maximum Length
+        - Duration
+        - Maximum Value Within
+        - Matched to Local Storm Reports
+    '''
+    qc_to_module_dict = {'min_area' : '_remove_small_objects', 
+                         'merge_thresh' : '_merge', 
+                         'max_length' : '_remove_long_objects',
+                         'min_time' : '_remove_short_duration_objects',
+                         'max_thresh' : '_remove_low_intensity_objects',
+                         'match_to_lsr' : '_remove_objects_unmatched_to_lsrs'
+                        }
+    
+    def __call__(self, input_data, object_labels, object_properties, qc_params):
+        return self.quality_control(input_data, object_labels, object_properties, qc_params)
+        
+        
+    def quality_control(self, input_data, object_labels, object_properties, qc_params): 
+        """
+        Applies quality control to identified objects. 
+        Parameters:
+        -------------------------
+            object_labels, 2D numpy array of labeled objects
+            
+            object_properties, object properties calculated by skimage.measure.regionprops for object labels
+            
+            input_data, original 2D numpy array of data from which object_labels was generated from
+            
+            qc_params,  List of tuples or ordered dictionary of the quality control option to apply 
+                          and the corresponding criteria. E.g., to apply a minimum area threshold 
+                          qc_params = [('min_area', 10)]. 
+                Potential quality control
+                 - 'min_area', removing objects below the minimum area (in number of pixels)
+                 - 'merge_thresh', merging objects together closer than a minimum distance (in gridpoints)
+                 - 'max_length', removing objects with a major axis length greater the given criterion (in gridpoints)
+                 - 'min_time', removing objects with duration less than the given criterion (in time steps) 
+                 - 'max_thresh', removing objects if the Pth percentile value is less than the given value. 
+                                 For max, P=100 and min, P=0. For this quality control, use a nested tuple
+                                 E.g., qc_params = [('max_thresh', (value, P)]
+                 - 'match_to_lsr', remove objects not matched to an local storm report
+                For additional details, read the functions below. 
  
-		Returns:
-		-------------------------
-			2-tuple of (object_labels, object_props) 
-			object_labels, quality-controlled version of the original object_labels
-			object_props, object properties of the quality-controlled objects
-		"""
-		self.input_data = input_data
-		self.object_labels = object_labels
-		self.object_properties = object_properties
-		
-		if isinstance(qc_params, list):
-			qc_params = OrderedDict(qc_params)
-		self.qc_params = qc_params
-		
-		for qc_method in self.qc_params.keys():
-			getattr(self, self.qc_to_module_dict[qc_method])()
-			
-		return (self.object_labels, self.object_properties) 
+        Returns:
+        -------------------------
+            2-tuple of (object_labels, object_props) 
+            object_labels, quality-controlled version of the original object_labels
+            object_props, object properties of the quality-controlled objects
+        """
+        self.input_data = input_data
+        self.object_labels = object_labels
+        self.object_properties = object_properties
+        
+        if isinstance(qc_params, list):
+            qc_params = OrderedDict(qc_params)
+        self.qc_params = qc_params
+        
+        for qc_method in self.qc_params.keys():
+            getattr(self, self.qc_to_module_dict[qc_method])()
+            
+        return (self.object_labels, self.object_properties) 
 
-	def _remove_small_objects(self):
-		''' 
-		Removes objects with area less than min_area. Area measured by the number of
-		grid cells.
-		Args,
-			: input_data, 2D numpy array, original data from which the object labels were generated from.
-										  Used to recalculate the regionprops after qualtiy control is applied. 
-			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-			: min_area, int, minimum area (in number of grid points) of an object
-		'''
-		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8) 
-		j = 1
-		for region in self.object_properties:
-			 if region.area >= self.qc_params['min_area']:
-				 qc_object_labels[self.object_labels == region.label] = j 
-				 j+=1
-		qc_object_properties = regionprops( qc_object_labels, self.input_data,	) 
-		
-		self.object_labels = qc_object_labels
-		self.object_properties = qc_object_properties
+    def _remove_small_objects(self):
+        ''' 
+        Removes objects with area less than min_area. Area measured by the number of
+        grid cells.
+        Args,
+            : input_data, 2D numpy array, original data from which the object labels were generated from.
+                                          Used to recalculate the regionprops after qualtiy control is applied. 
+            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+            : min_area, int, minimum area (in number of grid points) of an object
+        '''
+        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8) 
+        j = 1
+        for region in self.object_properties:
+             if region.area >= self.qc_params['min_area']:
+                 qc_object_labels[self.object_labels == region.label] = j 
+                 j+=1
+        qc_object_properties = regionprops( qc_object_labels, self.input_data,  ) 
+        
+        self.object_labels = qc_object_labels
+        self.object_properties = qc_object_properties
 
-	def _remove_long_objects(self):
-		''' 
-		Removes objects with a major axis length greater than max_length 
-		Args,
-			: input_data, 2D numpy array, original data from which the object labels were generated from.
-										  Used to recalculate the regionprops after qualtiy control is applied. 
-			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-			: max_length, int, maximum object length (in grid point distances) 
-		'''
-		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-		j=1
-		for region in self.object_properties:
-			 if round(region.major_axis_length, 2) >= self.qc_params['max_length']:
-				 qc_object_labels[self.object_labels == region.label] = j
-				 j+=1
-		qc_object_properties = regionprops( qc_object_labels, self.input_data,	)
+    def _remove_long_objects(self):
+        ''' 
+        Removes objects with a major axis length greater than max_length 
+        Args,
+            : input_data, 2D numpy array, original data from which the object labels were generated from.
+                                          Used to recalculate the regionprops after qualtiy control is applied. 
+            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+            : max_length, int, maximum object length (in grid point distances) 
+        '''
+        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+        j=1
+        for region in self.object_properties:
+             if round(region.major_axis_length, 2) >= self.qc_params['max_length']:
+                 qc_object_labels[self.object_labels == region.label] = j
+                 j+=1
+        qc_object_properties = regionprops( qc_object_labels, self.input_data,  )
 
-		self.object_labels = qc_object_labels
-		self.object_properties = qc_object_properties
+        self.object_labels = qc_object_labels
+        self.object_properties = qc_object_properties
 
-	def _remove_low_intensity_objects(self):
-		''' 
-		Removes objects where the 75th percentile intensity is below the max_thresh
-		Args,
-			: input_data, 2D numpy array, original data from which the object labels were generated from.
-										  Used to recalculate the regionprops after qualtiy control is applied. 
-			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-			: max_thresh, float, intensity threshold for the 75th percentile
-		'''
-		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-		j=1
-		val, P = self.qc_params['max_thresh']
-		for region in self.object_properties: 
-			 if round( np.percentile(self.input_data[self.object_labels == region.label], P), 10) \
-				 >= round(val,10): 
-				 qc_object_labels[self.object_labels == region.label] = j
-				 j+=1
-		
-		qc_object_properties = regionprops( qc_object_labels, self.input_data, )
+    def _remove_low_intensity_objects(self):
+        ''' 
+        Removes objects where the 75th percentile intensity is below the max_thresh
+        Args,
+            : input_data, 2D numpy array, original data from which the object labels were generated from.
+                                          Used to recalculate the regionprops after qualtiy control is applied. 
+            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+            : max_thresh, float, intensity threshold for the 75th percentile
+        '''
+        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+        j=1
+        val, P = self.qc_params['max_thresh']
+        for region in self.object_properties: 
+             if round( np.percentile(self.input_data[self.object_labels == region.label], P), 10) \
+                 >= round(val,10): 
+                 qc_object_labels[self.object_labels == region.label] = j
+                 j+=1
+        
+        qc_object_properties = regionprops( qc_object_labels, self.input_data, )
 
-		self.object_labels = qc_object_labels
-		self.object_properties = qc_object_properties 
+        self.object_labels = qc_object_labels
+        self.object_properties = qc_object_properties 
 
-	def _remove_short_duration_objects(self): 
-		''' 
-		When identify objects over a time duration, removes objects existing for a duration less than min_time
-		Args,
-			: input_data, 2D numpy array, original data from which the object labels were generated from.
-										  Used to recalculate the regionprops after qualtiy control is applied. 
-			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-			: min_time, int, minimum duration (in terms of number of time steps) 
-			: time_argmax_idxs, When applying np.argmax over time dimensions of an array
-		'''
-		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-		j=1
-		time_argmax_idxs = self.qc_params['min_time'][1]
-		for region in self.object_properties:	  
-			 duration = len( np.unique( time_argmax_idxs[self.object_labels == region.label] ))	 
-			 if duration >= self.qc_params['min_time'][0]:
-				 qc_object_labels[self.object_labels == region.label] = j
-				 j+=1
+    def _remove_short_duration_objects(self): 
+        ''' 
+        When identify objects over a time duration, removes objects existing for a duration less than min_time
+        Args,
+            : input_data, 2D numpy array, original data from which the object labels were generated from.
+                                          Used to recalculate the regionprops after qualtiy control is applied. 
+            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+            : min_time, int, minimum duration (in terms of number of time steps) 
+            : time_argmax_idxs, When applying np.argmax over time dimensions of an array
+        '''
+        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+        j=1
+        time_argmax_idxs = self.qc_params['min_time'][1]
+        for region in self.object_properties:     
+             duration = len( np.unique( time_argmax_idxs[self.object_labels == region.label] ))  
+             if duration >= self.qc_params['min_time'][0]:
+                 qc_object_labels[self.object_labels == region.label] = j
+                 j+=1
 
-		qc_object_properties = regionprops( qc_object_labels, self.input_data, )		
-		
-		self.object_labels = qc_object_labels
-		self.object_properties = qc_object_properties
+        qc_object_properties = regionprops( qc_object_labels, self.input_data, )        
+        
+        self.object_labels = qc_object_labels
+        self.object_properties = qc_object_properties
 
-	def _merge(self):
-		''' 
-		Merges near-by objects to limit discontinuous objects from counting as multiple objects.
-		Applicable when using the single threshold object identification method. 
-		Args,
-			: input_data, 2D numpy array, original data from which the object labels were generated from.
-										  Used to recalculate the regionprops after qualtiy control is applied. 
-			: object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
-			: merge_thresh, float, merging distance (objects closer than the merging distance 
-								   are combined together; in grid point distance)
-		'''
-		qc_object_labels = np.copy( self.object_labels ) 
-		original_labels = np.unique(qc_object_labels)[1:] #[label for label in np.unique(qc_object_labels)[1:]]
-		remaining_labels = np.unique(qc_object_labels)[1:]	#[label for label in np.unique(qc_object_labels)[1:]]
-		for label in original_labels:
-			# Does 'label' still exist? 
-			if int(label) in remaining_labels:
-				y_idx, x_idx = np.where( qc_object_labels == label )
-				label_xy_stack = np.dstack([x_idx.ravel(), y_idx.ravel()])[0]
-				region_tree = KDTree( label_xy_stack )
-				qc_object_labels, remaining_labels = loop_label_merge(
-				region_tree,original_labels.astype(np.int64), remaining_labels.astype(np.int64), np.int64(label), 
-				qc_object_labels.astype(np.int64), np.int64(self.qc_params['merge_thresh'])
-				)
-							
-		remaining_labels = np.unique(qc_object_labels)[1:]
-		for i, label in enumerate(remaining_labels):
-			qc_object_labels[qc_object_labels==label] = int(i+1) 
+    def _merge(self):
+        ''' 
+        Merges near-by objects to limit discontinuous objects from counting as multiple objects.
+        Applicable when using the single threshold object identification method. 
+        Args,
+            : input_data, 2D numpy array, original data from which the object labels were generated from.
+                                          Used to recalculate the regionprops after qualtiy control is applied. 
+            : object_labels_and_props, 2-tuple of 2D np array of object labels and the associated regionprops object 
+            : merge_thresh, float, merging distance (objects closer than the merging distance 
+                                   are combined together; in grid point distance)
+        '''
+        qc_object_labels = np.copy( self.object_labels ) 
+        original_labels = np.unique(qc_object_labels)[1:] #[label for label in np.unique(qc_object_labels)[1:]]
+        remaining_labels = np.unique(qc_object_labels)[1:]  #[label for label in np.unique(qc_object_labels)[1:]]
+        for label in original_labels:
+            # Does 'label' still exist? 
+            if int(label) in remaining_labels:
+                y_idx, x_idx = np.where( qc_object_labels == label )
+                label_xy_stack = np.dstack([x_idx.ravel(), y_idx.ravel()])[0]
+                region_tree = KDTree( label_xy_stack )
+                qc_object_labels, remaining_labels = loop_label_merge(
+                region_tree,original_labels.astype(np.int64), remaining_labels.astype(np.int64), np.int64(label), 
+                qc_object_labels.astype(np.int64), np.int64(self.qc_params['merge_thresh'])
+                )
+                            
+        remaining_labels = np.unique(qc_object_labels)[1:]
+        for i, label in enumerate(remaining_labels):
+            qc_object_labels[qc_object_labels==label] = int(i+1) 
 
-		qc_object_properties = regionprops( qc_object_labels, self.input_data, )
-		self.object_labels = qc_object_labels
-		self.object_properties = qc_object_properties
+        qc_object_properties = regionprops( qc_object_labels, self.input_data, )
+        self.object_labels = qc_object_labels
+        self.object_properties = qc_object_properties
 
-	def _remove_objects_unmatched_to_lsrs(self):
-		'''
-		Removes objects unmatched to Local Storm Reports (LSRs).
-		'''
-		qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
-		j=1
-		for region in self.object_properties:
-			kdbelled_points, labelled_datatree = spatial.cKDTree( region.coords )
-			dist_btw_region_and_lsr, _ = kdtree.query( self.qc_params['match_to_lsr']['lsr_points'] )
-			if round( np.amin( dist_btw_region_and_lsr ), 10) < self.qc_params['match_to_lsr']['dist_to_lsr']:
-				qc_object_labels[self.object_labels == region.label] = j
-				j+=1
-			
-		qc_object_properties = regionprops( qc_object_labels, self.input_data, )
-		self.object_labels = qc_object_labels
-		self.object_properties = qc_object_properties
+    def _remove_objects_unmatched_to_lsrs(self):
+        '''
+        Removes objects unmatched to Local Storm Reports (LSRs).
+        '''
+        qc_object_labels = np.zeros( self.object_labels.shape, dtype=np.int8)
+        j=1
+        for region in self.object_properties:
+            kdbelled_points, labelled_datatree = spatial.cKDTree( region.coords )
+            dist_btw_region_and_lsr, _ = kdtree.query( self.qc_params['match_to_lsr']['lsr_points'] )
+            if round( np.amin( dist_btw_region_and_lsr ), 10) < self.qc_params['match_to_lsr']['dist_to_lsr']:
+                qc_object_labels[self.object_labels == region.label] = j
+                j+=1
+            
+        qc_object_properties = regionprops( qc_object_labels, self.input_data, )
+        self.object_labels = qc_object_labels
+        self.object_properties = qc_object_properties

--- a/monte_python/storm_mode_classifier.py
+++ b/monte_python/storm_mode_classifier.py
@@ -5,272 +5,272 @@ from .object_quality_control import QualityControler
 import numpy as np 
 
 class StormModeClassifier:
-    """
-    StormModeClassifier is 7-scheme storm mode classification method developed by 
-    Potvin et al. First, image segmentation creates composite reflectivity and 
-    mid-level rotation regions using a single-threshold method. From the combination 
-    of these two fields, the initial storm mode is determined as one of the following:
-    the following:
-     (1) NONROT
-     (2) ROTATE
-     (3) QLCS
-     (4) AMORPHOUS
-    Through an iterative process, a higher reflectivity threshold is used to 
-    identify and classify embedded storms. The final modes include:
-     (1) ORDINARY 
-     (2) SUPERCELL 
-     (3) QLCS
-     (4) SUPERCELL CLUSTER (SUP_CLUST)
-     (5) ORDINARY QLCS CELL (QLCS_ORD)
-     (6) ROTATING QLCS CELL (QLCS_MESO)
-     (7) OTHER
-    
-    Authors: Corey Potvin (NOAA NSSL), Montgomery Flora (OU/CIWRO)
-    
-    Parameters
-    ----------------
-    dbz_thresh : float (default = 43.0)
-        The composite reflectivity threshold used for object identification. 
-        
-    rot_thresh : float (default = 55.0)
-        The mid-level rotation threshold used for object identification. 
-        Default is for WoFS mid-level updraft helicity. 
-        
-    dbz_qc_params : list of tuples (default = None) 
-        QC parameters for the composite reflectivity object identification. 
-        See monte_python.object_quality_control.QualityControler for more details
-        The default is None and uses the parameters for WoFS data from Potvin et al. 2022, 
-    
-    rot_qc_params : list of tuples (default = None) 
-        QC parameters for the mid-level rotation object identification. 
-        See monte_python.object_quality_control.QualityControler for more details
-        The default is None and uses the parameters for WoFS data from Potvin et al. 2022
-    
-    emb_qc_params : list of tuples (default = None) 
-        QC parameters for the embedded composite reflectivity object identification. 
-        See monte_python.object_quality_control.QualityControler for more details
-        The default is None and uses the parameters for WoFS data from Potvin et al. 2022
-    
-    grid_spacing : integer/float
-        The data grid spacing in meters. 
-    
-    Attributes
-    --------------
-    converter : dict 
-        The conversion between the storm modes and their integer labels 
-    
-    """
-    MODES = ['ORDINARY', 
-             'SUPERCELL', 
-             'QLCS', 
-             'SUP_CLUST', 
-             'QLCS_ORD', 
-             'QLCS_MESO', 
-             'OTHER']
-    
-    
-    def __init__(self, dbz_thresh=43., rot_thresh=55., grid_spacing=3000, 
-                 dbz_qc_params=None, rot_qc_params=None, emb_qc_params = None):
-        
-        self._dbz_thresh = dbz_thresh
-        self._rot_thresh = rot_thresh
-        self._ANALYSIS_DX = grid_spacing
-        
-        if dbz_qc_params is None:
-            self._dbz_qc_params =  [
-                    ("min_area", 15),
-                    ("merge_thresh", 3),
-                    ("max_thresh", (44.93, 100)),
-                ]
-        else:
-            self._dbz_qc_params = dbz_qc_params
-        
-        if rot_qc_params is None:
-            self._rot_qc_params = [
-                                ("merge_thresh", 1),
-                                ("min_area", 5),
-                               ]
-        else:
-            self._rot_qc_params = rot_qc_params
-        
-        if emb_qc_params is None:
-            self._emb_qc_params =  [
-                ("min_area", 10),
-                ("merge_thresh", 0),
-                ("max_thresh", (44.93, 100)),
-                ]
-        else:
-            self._emb_qc_params = emb_qc_params
-    
-    
-        if not isinstance(self._dbz_thresh, float):
-            raise ValueError('dbz_thresh must be a float!')
-        
-        if not isinstance(self._rot_thresh, float):
-            raise ValueError('rot_thresh must be a float!')
-        
-        if not isinstance(self._dbz_qc_params, list):
-            raise ValueError('dbz_qc_params must be a list!')
-        
-        if not isinstance(self._rot_qc_params, list):
-            raise ValueError('rot_qc_params must be a list!')
-    
-    
-    @property
-    def converter(self):
-        digitize_types = {n+1 : key for n, key in enumerate(self.MODES)}
-        return digitize_types
-    
-    
-    def _label_and_qc(self, input_data, thresh, qc_params):
-        """ Label the data and apply QC """
-        labels, label_props =  label(
-            input_data=input_data,
-            method="single_threshold",
-            params={"bdry_thresh": thresh},
-        )
+	"""
+	StormModeClassifier is 7-scheme storm mode classification method developed by 
+	Potvin et al. First, image segmentation creates composite reflectivity and 
+	mid-level rotation regions using a single-threshold method. From the combination 
+	of these two fields, the initial storm mode is determined as one of the following:
+	the following:
+	 (1) NONROT
+	 (2) ROTATE
+	 (3) QLCS
+	 (4) AMORPHOUS
+	Through an iterative process, a higher reflectivity threshold is used to 
+	identify and classify embedded storms. The final modes include:
+	 (1) ORDINARY 
+	 (2) SUPERCELL 
+	 (3) QLCS
+	 (4) SUPERCELL CLUSTER (SUP_CLUST)
+	 (5) ORDINARY QLCS CELL (QLCS_ORD)
+	 (6) ROTATING QLCS CELL (QLCS_MESO)
+	 (7) OTHER
+	
+	Authors: Corey Potvin (NOAA NSSL), Montgomery Flora (OU/CIWRO)
+	
+	Parameters
+	----------------
+	dbz_thresh : float (default = 43.0)
+		The composite reflectivity threshold used for object identification. 
+		
+	rot_thresh : float (default = 55.0)
+		The mid-level rotation threshold used for object identification. 
+		Default is for WoFS mid-level updraft helicity. 
+		
+	dbz_qc_params : list of tuples (default = None) 
+		QC parameters for the composite reflectivity object identification. 
+		See monte_python.object_quality_control.QualityControler for more details
+		The default is None and uses the parameters for WoFS data from Potvin et al. 2022, 
+	
+	rot_qc_params : list of tuples (default = None) 
+		QC parameters for the mid-level rotation object identification. 
+		See monte_python.object_quality_control.QualityControler for more details
+		The default is None and uses the parameters for WoFS data from Potvin et al. 2022
+	
+	emb_qc_params : list of tuples (default = None) 
+		QC parameters for the embedded composite reflectivity object identification. 
+		See monte_python.object_quality_control.QualityControler for more details
+		The default is None and uses the parameters for WoFS data from Potvin et al. 2022
+	
+	grid_spacing : integer/float
+		The data grid spacing in meters. 
+	
+	Attributes
+	--------------
+	converter : dict 
+		The conversion between the storm modes and their integer labels 
+	
+	"""
+	MODES = ['ORDINARY', 
+			 'SUPERCELL', 
+			 'QLCS', 
+			 'SUP_CLUST', 
+			 'QLCS_ORD', 
+			 'QLCS_MESO', 
+			 'OTHER']
+	
+	
+	def __init__(self, dbz_thresh=43., rot_thresh=55., grid_spacing=3000, 
+				 dbz_qc_params=None, rot_qc_params=None, emb_qc_params = None):
+		
+		self._dbz_thresh = dbz_thresh
+		self._rot_thresh = rot_thresh
+		self._ANALYSIS_DX = grid_spacing
+		
+		if dbz_qc_params is None:
+			self._dbz_qc_params =  [
+					("min_area", 15),
+					("merge_thresh", 3),
+					("max_thresh", (44.93, 100)),
+				]
+		else:
+			self._dbz_qc_params = dbz_qc_params
+		
+		if rot_qc_params is None:
+			self._rot_qc_params = [
+								("merge_thresh", 1),
+								("min_area", 5),
+							   ]
+		else:
+			self._rot_qc_params = rot_qc_params
+		
+		if emb_qc_params is None:
+			self._emb_qc_params =  [
+				("min_area", 10),
+				("merge_thresh", 0),
+				("max_thresh", (44.93, 100)),
+				]
+		else:
+			self._emb_qc_params = emb_qc_params
+	
+	
+		if not isinstance(self._dbz_thresh, float):
+			raise ValueError('dbz_thresh must be a float!')
+		
+		if not isinstance(self._rot_thresh, float):
+			raise ValueError('rot_thresh must be a float!')
+		
+		if not isinstance(self._dbz_qc_params, list):
+			raise ValueError('dbz_qc_params must be a list!')
+		
+		if not isinstance(self._rot_qc_params, list):
+			raise ValueError('rot_qc_params must be a list!')
+	
+	
+	@property
+	def converter(self):
+		digitize_types = {n+1 : key for n, key in enumerate(self.MODES)}
+		return digitize_types
+	
+	
+	def _label_and_qc(self, input_data, thresh, qc_params):
+		""" Label the data and apply QC """
+		labels, label_props =  label(
+			input_data=input_data,
+			method="single_threshold",
+			params={"bdry_thresh": thresh},
+		)
   
-        labels_qced, props_qced = QualityControler().quality_control(
-                    object_labels=labels,
-                    object_properties=label_props,
-                    input_data=input_data,
-                    qc_params=qc_params,
-                )
+		labels_qced, props_qced = QualityControler().quality_control(
+					object_labels=labels,
+					object_properties=label_props,
+					input_data=input_data,
+					qc_params=qc_params,
+				)
 
-        return labels_qced, props_qced
-    
-    def classify(self, dbz_vals, rot_vals):
-        """
-        Identify and classify composite reflectivity objects using the 
-        7-mode scheme from Potvin et al. 
-        
-        Parameters
-        ---------------------
-            dbz_vals, array-like with shape (NY, NX)
-                Composite reflectivity field at single time to identify and classify.
-            
-            rot_vals, array-like with shape (NY, NX) 
-                Optional 30-minute time-maximum mid-level rotation field to aid in 
-                the storm mode classification. For NWP, we recommend mid-level UH and 
-                for radar data, azimuthal shear. Expected to be a 
-                time-composite field (e.g., max over the last 30 or 60 minutes).
-            
-        Returns
-        ---------------------
-           storm_modes : array of shape (NY, NX) 
-               Integer labelled array where values 1-7 indicate the storm mode. 
-               
-           merged_labels : array of shape (NY, NX)
-               Integer labelled array of the composite reflectivity objects 
-               (including the embedded regions).
-               
-           dbz_props : skimage.measure.RegionProps objects 
-               Object properties of the the merged_labels array.
+		return labels_qced, props_qced
+	
+	def classify(self, dbz_vals, rot_vals):
+		"""
+		Identify and classify composite reflectivity objects using the 
+		7-mode scheme from Potvin et al. 
+		
+		Parameters
+		---------------------
+			dbz_vals, array-like with shape (NY, NX)
+				Composite reflectivity field at single time to identify and classify.
+			
+			rot_vals, array-like with shape (NY, NX) 
+				Optional 30-minute time-maximum mid-level rotation field to aid in 
+				the storm mode classification. For NWP, we recommend mid-level UH and 
+				for radar data, azimuthal shear. Expected to be a 
+				time-composite field (e.g., max over the last 30 or 60 minutes).
+			
+		Returns
+		---------------------
+		   storm_modes : array of shape (NY, NX) 
+			   Integer labelled array where values 1-7 indicate the storm mode. 
+			   
+		   merged_labels : array of shape (NY, NX)
+			   Integer labelled array of the composite reflectivity objects 
+			   (including the embedded regions).
+			   
+		   dbz_props : skimage.measure.RegionProps objects 
+			   Object properties of the the merged_labels array.
 
-        """
-        if np.ndim(dbz_vals) != 2:
-            raise ValueError('dbz_vals must be a 2D array')
-            
-        if np.ndim(rot_vals) != 2:
-            raise ValueError('rot_vals must be a 2D array')    
-        
-        dbz_labels, dbz_props = self._label_and_qc(dbz_vals, self._dbz_thresh, self._dbz_qc_params)
-        rot_labels, rot_props = self._label_and_qc(rot_vals, self._rot_thresh, self._rot_qc_params)   
-    
-        storm_types, labels_with_matched_rotation = get_storm_types(
-                        None,
-                        dbz_labels,
-                        dbz_props,
-                        dbz_vals,
-                        rot_labels,
-                        rot_props,
-                        rot_vals,
-                        ANALYSIS_DX= self._ANALYSIS_DX
-                    )
-    
-        min_thres_vals = np.arange(
-                            self._dbz_thresh + 0, self._dbz_thresh + 23.1, 1
-                        )
-        
-        for itr, min_thres in enumerate(min_thres_vals):
-            (
-             storm_types,
-             storm_embs,
-             dbz_props,
-             storm_depths,
-                ) = get_constituent_storms(
-                                None,
-                                min_thres,
-                                self._emb_qc_params,
-                                storm_types,
-                                dbz_labels,
-                                dbz_props,
-                                dbz_vals,
-                                rot_labels,
-                                rot_props,
-                                rot_vals,
-                                itr + 1,
-                                len(min_thres_vals),
-                                self._ANALYSIS_DX,
-                            )
+		"""
+		if np.ndim(dbz_vals) != 2:
+			raise ValueError('dbz_vals must be a 2D array')
+			
+		if np.ndim(rot_vals) != 2:
+			raise ValueError('rot_vals must be a 2D array')	   
+		
+		dbz_labels, dbz_props = self._label_and_qc(dbz_vals, self._dbz_thresh, self._dbz_qc_params)
+		rot_labels, rot_props = self._label_and_qc(rot_vals, self._rot_thresh, self._rot_qc_params)	  
+		
+		storm_types, labels_with_matched_rotation = get_storm_types(
+						None,
+						dbz_labels,
+						dbz_props,
+						dbz_vals,
+						rot_labels,
+						rot_props,
+						rot_vals,
+						ANALYSIS_DX= self._ANALYSIS_DX
+					)
+					
+		min_thres_vals = np.arange(
+							self._dbz_thresh + 0, self._dbz_thresh + 23.1, 1
+						)
+		for itr, min_thres in enumerate(min_thres_vals):
+			(
+			 storm_types,
+			 storm_embs,
+			 dbz_props,
+			 storm_depths,
+				) = get_constituent_storms(
+								None,
+								min_thres,
+								self._emb_qc_params,
+								storm_types,
+								dbz_labels,
+								dbz_props,
+								dbz_vals,
+								rot_labels,
+								rot_props,
+								rot_vals,
+								itr + 1,
+								len(min_thres_vals),
+								self._ANALYSIS_DX,
+							)
 
-        for n in range(len(dbz_props)):
-            dbz_props[n].label = n + 1
-    
-        storm_modes, merged_labels = self._embedding_to_2d_array( dbz_vals.shape,
-                                                                 dbz_props, 
-                                                                storm_types, 
-                                                                storm_depths, 
-                                                                storm_embs)
-        return storm_modes, merged_labels, dbz_props    
-        
-    def get_storm_labels(self, storm_emb, storm_type):
-        convert_labels = {'ROTATE': 'SUPERCELL', 
-                      'NONROT': 'ORDINARY', 
-                      'SEGMENT': 'OTHER', 
-                      'QLCS': 'QLCS', 
-                      'CLUSTER': 'OTHER', 
-                      'AMORPHOUS': 'OTHER', 
-                      'QLCS_ROT': 'QLCS_MESO', 
-                      'QLCS_NON': 'QLCS_ORD', 
-                      'CLUS_ROT': 'SUPERCELL', 
-                      'CLUS_NON': 'ORDINARY', 
-                      'SUP_CLUST': 'SUP_CLUST',
-                      'CELL_NON': 'ORDINARY', 
-                      'CELL_ROT': 'SUPERCELL'}
+		for n in range(len(dbz_props)):
+			dbz_props[n].label = n + 1
 
-        digitize_types = {y:x for x,y in self.converter.items()}
-        
-        if storm_emb == 'NONEMB':
-            label = storm_type
-        else:
-            label = f'{storm_emb[4:]}_{storm_type[:3]}'
+		storm_modes, merged_labels = self._embedding_to_2d_array( dbz_vals.shape,
+																 dbz_props, 
+																storm_types, 
+																storm_depths, 
+																storm_embs)
 
-        type_str = convert_labels[label]
-        type_int = int(digitize_types[type_str])
+		return storm_modes, merged_labels, dbz_props	
+		
+	def get_storm_labels(self, storm_emb, storm_type):
+		convert_labels = {'ROTATE': 'SUPERCELL', 
+					  'NONROT': 'ORDINARY', 
+					  'SEGMENT': 'OTHER', 
+					  'QLCS': 'QLCS', 
+					  'CLUSTER': 'OTHER', 
+					  'AMORPHOUS': 'OTHER', 
+					  'QLCS_ROT': 'QLCS_MESO', 
+					  'QLCS_NON': 'QLCS_ORD', 
+					  'CLUS_ROT': 'SUPERCELL', 
+					  'CLUS_NON': 'ORDINARY', 
+					  'SUP_CLUST': 'SUP_CLUST',
+					  'CELL_NON': 'ORDINARY', 
+					  'CELL_ROT': 'SUPERCELL'}
 
-        return type_int, type_str
-    
-    def _embedding_to_2d_array(self, shape, dbz_props, storm_modes, storm_depths, storm_embs):
-        """ Convert embedded modes and labels to 2D array """
-        storm_mode_array = np.zeros(shape, dtype=int)
-        merged_labels = np.zeros(shape, dtype=int)
-        
-        for storm_depth in range(3):
-            inds = np.where(np.array(storm_depths)==storm_depth)[0]
-            # get regionprops, storm types, and embedded status for each storm of current depth
-            props = [dbz_props[index] for index in inds]
-            types = [storm_modes[index] for index in inds]
-            embs = [storm_embs[index] for index in inds]
-            
-            for region, mode, emb in zip(props, types, embs):
-                # Insert each storm into labels array and merged labels array 
-                # (labels in latter will later be overwritten by collocated deeper storms)
-                coords = region.coords
-                merged_labels[coords[:,0], coords[:,1]] = region.label
-                # based on storm type and embedded status, get integer corresponding to storm mode, 
-                # and insert into storm modes array
-                storm_type_int, storm_type_str = self.get_storm_labels(emb, mode)
-                storm_mode_array[coords[:,0], coords[:,1]] = storm_type_int
-        
-        return storm_mode_array, merged_labels
+		digitize_types = {y:x for x,y in self.converter.items()}
+		
+		if storm_emb == 'NONEMB':
+			label = storm_type
+		else:
+			label = f'{storm_emb[4:]}_{storm_type[:3]}'
+
+		type_str = convert_labels[label]
+		type_int = int(digitize_types[type_str])
+
+		return type_int, type_str
+	
+	def _embedding_to_2d_array(self, shape, dbz_props, storm_modes, storm_depths, storm_embs):
+		""" Convert embedded modes and labels to 2D array """
+		storm_mode_array = np.zeros(shape, dtype=int)
+		merged_labels = np.zeros(shape, dtype=int)
+		
+		for storm_depth in range(3):
+			inds = np.where(np.array(storm_depths)==storm_depth)[0]
+			# get regionprops, storm types, and embedded status for each storm of current depth
+			props = [dbz_props[index] for index in inds]
+			types = [storm_modes[index] for index in inds]
+			embs = [storm_embs[index] for index in inds]
+			
+			for region, mode, emb in zip(props, types, embs):
+				# Insert each storm into labels array and merged labels array 
+				# (labels in latter will later be overwritten by collocated deeper storms)
+				coords = region.coords
+				merged_labels[coords[:,0], coords[:,1]] = region.label
+				# based on storm type and embedded status, get integer corresponding to storm mode, 
+				# and insert into storm modes array
+				storm_type_int, storm_type_str = self.get_storm_labels(emb, mode)
+				storm_mode_array[coords[:,0], coords[:,1]] = storm_type_int
+		
+		return storm_mode_array, merged_labels

--- a/monte_python/storm_mode_classifier.py
+++ b/monte_python/storm_mode_classifier.py
@@ -5,272 +5,272 @@ from .object_quality_control import QualityControler
 import numpy as np 
 
 class StormModeClassifier:
-	"""
-	StormModeClassifier is 7-scheme storm mode classification method developed by 
-	Potvin et al. First, image segmentation creates composite reflectivity and 
-	mid-level rotation regions using a single-threshold method. From the combination 
-	of these two fields, the initial storm mode is determined as one of the following:
-	the following:
-	 (1) NONROT
-	 (2) ROTATE
-	 (3) QLCS
-	 (4) AMORPHOUS
-	Through an iterative process, a higher reflectivity threshold is used to 
-	identify and classify embedded storms. The final modes include:
-	 (1) ORDINARY 
-	 (2) SUPERCELL 
-	 (3) QLCS
-	 (4) SUPERCELL CLUSTER (SUP_CLUST)
-	 (5) ORDINARY QLCS CELL (QLCS_ORD)
-	 (6) ROTATING QLCS CELL (QLCS_MESO)
-	 (7) OTHER
-	
-	Authors: Corey Potvin (NOAA NSSL), Montgomery Flora (OU/CIWRO)
-	
-	Parameters
-	----------------
-	dbz_thresh : float (default = 43.0)
-		The composite reflectivity threshold used for object identification. 
-		
-	rot_thresh : float (default = 55.0)
-		The mid-level rotation threshold used for object identification. 
-		Default is for WoFS mid-level updraft helicity. 
-		
-	dbz_qc_params : list of tuples (default = None) 
-		QC parameters for the composite reflectivity object identification. 
-		See monte_python.object_quality_control.QualityControler for more details
-		The default is None and uses the parameters for WoFS data from Potvin et al. 2022, 
-	
-	rot_qc_params : list of tuples (default = None) 
-		QC parameters for the mid-level rotation object identification. 
-		See monte_python.object_quality_control.QualityControler for more details
-		The default is None and uses the parameters for WoFS data from Potvin et al. 2022
-	
-	emb_qc_params : list of tuples (default = None) 
-		QC parameters for the embedded composite reflectivity object identification. 
-		See monte_python.object_quality_control.QualityControler for more details
-		The default is None and uses the parameters for WoFS data from Potvin et al. 2022
-	
-	grid_spacing : integer/float
-		The data grid spacing in meters. 
-	
-	Attributes
-	--------------
-	converter : dict 
-		The conversion between the storm modes and their integer labels 
-	
-	"""
-	MODES = ['ORDINARY', 
-			 'SUPERCELL', 
-			 'QLCS', 
-			 'SUP_CLUST', 
-			 'QLCS_ORD', 
-			 'QLCS_MESO', 
-			 'OTHER']
-	
-	
-	def __init__(self, dbz_thresh=43., rot_thresh=55., grid_spacing=3000, 
-				 dbz_qc_params=None, rot_qc_params=None, emb_qc_params = None):
-		
-		self._dbz_thresh = dbz_thresh
-		self._rot_thresh = rot_thresh
-		self._ANALYSIS_DX = grid_spacing
-		
-		if dbz_qc_params is None:
-			self._dbz_qc_params =  [
-					("min_area", 15),
-					("merge_thresh", 3),
-					("max_thresh", (44.93, 100)),
-				]
-		else:
-			self._dbz_qc_params = dbz_qc_params
-		
-		if rot_qc_params is None:
-			self._rot_qc_params = [
-								("merge_thresh", 1),
-								("min_area", 5),
-							   ]
-		else:
-			self._rot_qc_params = rot_qc_params
-		
-		if emb_qc_params is None:
-			self._emb_qc_params =  [
-				("min_area", 10),
-				("merge_thresh", 0),
-				("max_thresh", (44.93, 100)),
-				]
-		else:
-			self._emb_qc_params = emb_qc_params
-	
-	
-		if not isinstance(self._dbz_thresh, float):
-			raise ValueError('dbz_thresh must be a float!')
-		
-		if not isinstance(self._rot_thresh, float):
-			raise ValueError('rot_thresh must be a float!')
-		
-		if not isinstance(self._dbz_qc_params, list):
-			raise ValueError('dbz_qc_params must be a list!')
-		
-		if not isinstance(self._rot_qc_params, list):
-			raise ValueError('rot_qc_params must be a list!')
-	
-	
-	@property
-	def converter(self):
-		digitize_types = {n+1 : key for n, key in enumerate(self.MODES)}
-		return digitize_types
-	
-	
-	def _label_and_qc(self, input_data, thresh, qc_params):
-		""" Label the data and apply QC """
-		labels, label_props =  label(
-			input_data=input_data,
-			method="single_threshold",
-			params={"bdry_thresh": thresh},
-		)
+    """
+    StormModeClassifier is 7-scheme storm mode classification method developed by 
+    Potvin et al. First, image segmentation creates composite reflectivity and 
+    mid-level rotation regions using a single-threshold method. From the combination 
+    of these two fields, the initial storm mode is determined as one of the following:
+    the following:
+     (1) NONROT
+     (2) ROTATE
+     (3) QLCS
+     (4) AMORPHOUS
+    Through an iterative process, a higher reflectivity threshold is used to 
+    identify and classify embedded storms. The final modes include:
+     (1) ORDINARY 
+     (2) SUPERCELL 
+     (3) QLCS
+     (4) SUPERCELL CLUSTER (SUP_CLUST)
+     (5) ORDINARY QLCS CELL (QLCS_ORD)
+     (6) ROTATING QLCS CELL (QLCS_MESO)
+     (7) OTHER
+    
+    Authors: Corey Potvin (NOAA NSSL), Montgomery Flora (OU/CIWRO)
+    
+    Parameters
+    ----------------
+    dbz_thresh : float (default = 43.0)
+        The composite reflectivity threshold used for object identification. 
+        
+    rot_thresh : float (default = 55.0)
+        The mid-level rotation threshold used for object identification. 
+        Default is for WoFS mid-level updraft helicity. 
+        
+    dbz_qc_params : list of tuples (default = None) 
+        QC parameters for the composite reflectivity object identification. 
+        See monte_python.object_quality_control.QualityControler for more details
+        The default is None and uses the parameters for WoFS data from Potvin et al. 2022, 
+    
+    rot_qc_params : list of tuples (default = None) 
+        QC parameters for the mid-level rotation object identification. 
+        See monte_python.object_quality_control.QualityControler for more details
+        The default is None and uses the parameters for WoFS data from Potvin et al. 2022
+    
+    emb_qc_params : list of tuples (default = None) 
+        QC parameters for the embedded composite reflectivity object identification. 
+        See monte_python.object_quality_control.QualityControler for more details
+        The default is None and uses the parameters for WoFS data from Potvin et al. 2022
+    
+    grid_spacing : integer/float
+        The data grid spacing in meters. 
+    
+    Attributes
+    --------------
+    converter : dict 
+        The conversion between the storm modes and their integer labels 
+    
+    """
+    MODES = ['ORDINARY', 
+             'SUPERCELL', 
+             'QLCS', 
+             'SUP_CLUST', 
+             'QLCS_ORD', 
+             'QLCS_MESO', 
+             'OTHER']
+    
+    
+    def __init__(self, dbz_thresh=43., rot_thresh=55., grid_spacing=3000, 
+                 dbz_qc_params=None, rot_qc_params=None, emb_qc_params = None):
+        
+        self._dbz_thresh = dbz_thresh
+        self._rot_thresh = rot_thresh
+        self._ANALYSIS_DX = grid_spacing
+        
+        if dbz_qc_params is None:
+            self._dbz_qc_params =  [
+                    ("min_area", 15),
+                    ("merge_thresh", 3),
+                    ("max_thresh", (44.93, 100)),
+                ]
+        else:
+            self._dbz_qc_params = dbz_qc_params
+        
+        if rot_qc_params is None:
+            self._rot_qc_params = [
+                                ("merge_thresh", 1),
+                                ("min_area", 5),
+                               ]
+        else:
+            self._rot_qc_params = rot_qc_params
+        
+        if emb_qc_params is None:
+            self._emb_qc_params =  [
+                ("min_area", 10),
+                ("merge_thresh", 0),
+                ("max_thresh", (44.93, 100)),
+                ]
+        else:
+            self._emb_qc_params = emb_qc_params
+    
+    
+        if not isinstance(self._dbz_thresh, float):
+            raise ValueError('dbz_thresh must be a float!')
+        
+        if not isinstance(self._rot_thresh, float):
+            raise ValueError('rot_thresh must be a float!')
+        
+        if not isinstance(self._dbz_qc_params, list):
+            raise ValueError('dbz_qc_params must be a list!')
+        
+        if not isinstance(self._rot_qc_params, list):
+            raise ValueError('rot_qc_params must be a list!')
+    
+    
+    @property
+    def converter(self):
+        digitize_types = {n+1 : key for n, key in enumerate(self.MODES)}
+        return digitize_types
+    
+    
+    def _label_and_qc(self, input_data, thresh, qc_params):
+        """ Label the data and apply QC """
+        labels, label_props =  label(
+            input_data=input_data,
+            method="single_threshold",
+            params={"bdry_thresh": thresh},
+        )
   
-		labels_qced, props_qced = QualityControler().quality_control(
-					object_labels=labels,
-					object_properties=label_props,
-					input_data=input_data,
-					qc_params=qc_params,
-				)
+        labels_qced, props_qced = QualityControler().quality_control(
+                    object_labels=labels,
+                    object_properties=label_props,
+                    input_data=input_data,
+                    qc_params=qc_params,
+                )
 
-		return labels_qced, props_qced
-	
-	def classify(self, dbz_vals, rot_vals):
-		"""
-		Identify and classify composite reflectivity objects using the 
-		7-mode scheme from Potvin et al. 
-		
-		Parameters
-		---------------------
-			dbz_vals, array-like with shape (NY, NX)
-				Composite reflectivity field at single time to identify and classify.
-			
-			rot_vals, array-like with shape (NY, NX) 
-				Optional 30-minute time-maximum mid-level rotation field to aid in 
-				the storm mode classification. For NWP, we recommend mid-level UH and 
-				for radar data, azimuthal shear. Expected to be a 
-				time-composite field (e.g., max over the last 30 or 60 minutes).
-			
-		Returns
-		---------------------
-		   storm_modes : array of shape (NY, NX) 
-			   Integer labelled array where values 1-7 indicate the storm mode. 
-			   
-		   merged_labels : array of shape (NY, NX)
-			   Integer labelled array of the composite reflectivity objects 
-			   (including the embedded regions).
-			   
-		   dbz_props : skimage.measure.RegionProps objects 
-			   Object properties of the the merged_labels array.
+        return labels_qced, props_qced
+    
+    def classify(self, dbz_vals, rot_vals):
+        """
+        Identify and classify composite reflectivity objects using the 
+        7-mode scheme from Potvin et al. 
+        
+        Parameters
+        ---------------------
+            dbz_vals, array-like with shape (NY, NX)
+                Composite reflectivity field at single time to identify and classify.
+            
+            rot_vals, array-like with shape (NY, NX) 
+                Optional 30-minute time-maximum mid-level rotation field to aid in 
+                the storm mode classification. For NWP, we recommend mid-level UH and 
+                for radar data, azimuthal shear. Expected to be a 
+                time-composite field (e.g., max over the last 30 or 60 minutes).
+            
+        Returns
+        ---------------------
+           storm_modes : array of shape (NY, NX) 
+               Integer labelled array where values 1-7 indicate the storm mode. 
+               
+           merged_labels : array of shape (NY, NX)
+               Integer labelled array of the composite reflectivity objects 
+               (including the embedded regions).
+               
+           dbz_props : skimage.measure.RegionProps objects 
+               Object properties of the the merged_labels array.
 
-		"""
-		if np.ndim(dbz_vals) != 2:
-			raise ValueError('dbz_vals must be a 2D array')
-			
-		if np.ndim(rot_vals) != 2:
-			raise ValueError('rot_vals must be a 2D array')	   
-		
-		dbz_labels, dbz_props = self._label_and_qc(dbz_vals, self._dbz_thresh, self._dbz_qc_params)
-		rot_labels, rot_props = self._label_and_qc(rot_vals, self._rot_thresh, self._rot_qc_params)	  
-		
-		storm_types, labels_with_matched_rotation = get_storm_types(
-						None,
-						dbz_labels,
-						dbz_props,
-						dbz_vals,
-						rot_labels,
-						rot_props,
-						rot_vals,
-						ANALYSIS_DX= self._ANALYSIS_DX
-					)
-					
-		min_thres_vals = np.arange(
-							self._dbz_thresh + 0, self._dbz_thresh + 23.1, 1
-						)
-		for itr, min_thres in enumerate(min_thres_vals):
-			(
-			 storm_types,
-			 storm_embs,
-			 dbz_props,
-			 storm_depths,
-				) = get_constituent_storms(
-								None,
-								min_thres,
-								self._emb_qc_params,
-								storm_types,
-								dbz_labels,
-								dbz_props,
-								dbz_vals,
-								rot_labels,
-								rot_props,
-								rot_vals,
-								itr + 1,
-								len(min_thres_vals),
-								self._ANALYSIS_DX,
-							)
+        """
+        if np.ndim(dbz_vals) != 2:
+            raise ValueError('dbz_vals must be a 2D array')
+            
+        if np.ndim(rot_vals) != 2:
+            raise ValueError('rot_vals must be a 2D array')    
+        
+        dbz_labels, dbz_props = self._label_and_qc(dbz_vals, self._dbz_thresh, self._dbz_qc_params)
+        rot_labels, rot_props = self._label_and_qc(rot_vals, self._rot_thresh, self._rot_qc_params)   
+        
+        storm_types, labels_with_matched_rotation = get_storm_types(
+                        None,
+                        dbz_labels,
+                        dbz_props,
+                        dbz_vals,
+                        rot_labels,
+                        rot_props,
+                        rot_vals,
+                        ANALYSIS_DX= self._ANALYSIS_DX
+                    )
+                    
+        min_thres_vals = np.arange(
+                            self._dbz_thresh + 0, self._dbz_thresh + 23.1, 1
+                        )
+        for itr, min_thres in enumerate(min_thres_vals):
+            (
+             storm_types,
+             storm_embs,
+             dbz_props,
+             storm_depths,
+                ) = get_constituent_storms(
+                                None,
+                                min_thres,
+                                self._emb_qc_params,
+                                storm_types,
+                                dbz_labels,
+                                dbz_props,
+                                dbz_vals,
+                                rot_labels,
+                                rot_props,
+                                rot_vals,
+                                itr + 1,
+                                len(min_thres_vals),
+                                self._ANALYSIS_DX,
+                            )
 
-		for n in range(len(dbz_props)):
-			dbz_props[n].label = n + 1
+        for n in range(len(dbz_props)):
+            dbz_props[n].label = n + 1
 
-		storm_modes, merged_labels = self._embedding_to_2d_array( dbz_vals.shape,
-																 dbz_props, 
-																storm_types, 
-																storm_depths, 
-																storm_embs)
+        storm_modes, merged_labels = self._embedding_to_2d_array( dbz_vals.shape,
+                                                                 dbz_props, 
+                                                                storm_types, 
+                                                                storm_depths, 
+                                                                storm_embs)
 
-		return storm_modes, merged_labels, dbz_props	
-		
-	def get_storm_labels(self, storm_emb, storm_type):
-		convert_labels = {'ROTATE': 'SUPERCELL', 
-					  'NONROT': 'ORDINARY', 
-					  'SEGMENT': 'OTHER', 
-					  'QLCS': 'QLCS', 
-					  'CLUSTER': 'OTHER', 
-					  'AMORPHOUS': 'OTHER', 
-					  'QLCS_ROT': 'QLCS_MESO', 
-					  'QLCS_NON': 'QLCS_ORD', 
-					  'CLUS_ROT': 'SUPERCELL', 
-					  'CLUS_NON': 'ORDINARY', 
-					  'SUP_CLUST': 'SUP_CLUST',
-					  'CELL_NON': 'ORDINARY', 
-					  'CELL_ROT': 'SUPERCELL'}
+        return storm_modes, merged_labels, dbz_props    
+        
+    def get_storm_labels(self, storm_emb, storm_type):
+        convert_labels = {'ROTATE': 'SUPERCELL', 
+                      'NONROT': 'ORDINARY', 
+                      'SEGMENT': 'OTHER', 
+                      'QLCS': 'QLCS', 
+                      'CLUSTER': 'OTHER', 
+                      'AMORPHOUS': 'OTHER', 
+                      'QLCS_ROT': 'QLCS_MESO', 
+                      'QLCS_NON': 'QLCS_ORD', 
+                      'CLUS_ROT': 'SUPERCELL', 
+                      'CLUS_NON': 'ORDINARY', 
+                      'SUP_CLUST': 'SUP_CLUST',
+                      'CELL_NON': 'ORDINARY', 
+                      'CELL_ROT': 'SUPERCELL'}
 
-		digitize_types = {y:x for x,y in self.converter.items()}
-		
-		if storm_emb == 'NONEMB':
-			label = storm_type
-		else:
-			label = f'{storm_emb[4:]}_{storm_type[:3]}'
+        digitize_types = {y:x for x,y in self.converter.items()}
+        
+        if storm_emb == 'NONEMB':
+            label = storm_type
+        else:
+            label = f'{storm_emb[4:]}_{storm_type[:3]}'
 
-		type_str = convert_labels[label]
-		type_int = int(digitize_types[type_str])
+        type_str = convert_labels[label]
+        type_int = int(digitize_types[type_str])
 
-		return type_int, type_str
-	
-	def _embedding_to_2d_array(self, shape, dbz_props, storm_modes, storm_depths, storm_embs):
-		""" Convert embedded modes and labels to 2D array """
-		storm_mode_array = np.zeros(shape, dtype=int)
-		merged_labels = np.zeros(shape, dtype=int)
-		
-		for storm_depth in range(3):
-			inds = np.where(np.array(storm_depths)==storm_depth)[0]
-			# get regionprops, storm types, and embedded status for each storm of current depth
-			props = [dbz_props[index] for index in inds]
-			types = [storm_modes[index] for index in inds]
-			embs = [storm_embs[index] for index in inds]
-			
-			for region, mode, emb in zip(props, types, embs):
-				# Insert each storm into labels array and merged labels array 
-				# (labels in latter will later be overwritten by collocated deeper storms)
-				coords = region.coords
-				merged_labels[coords[:,0], coords[:,1]] = region.label
-				# based on storm type and embedded status, get integer corresponding to storm mode, 
-				# and insert into storm modes array
-				storm_type_int, storm_type_str = self.get_storm_labels(emb, mode)
-				storm_mode_array[coords[:,0], coords[:,1]] = storm_type_int
-		
-		return storm_mode_array, merged_labels
+        return type_int, type_str
+    
+    def _embedding_to_2d_array(self, shape, dbz_props, storm_modes, storm_depths, storm_embs):
+        """ Convert embedded modes and labels to 2D array """
+        storm_mode_array = np.zeros(shape, dtype=int)
+        merged_labels = np.zeros(shape, dtype=int)
+        
+        for storm_depth in range(3):
+            inds = np.where(np.array(storm_depths)==storm_depth)[0]
+            # get regionprops, storm types, and embedded status for each storm of current depth
+            props = [dbz_props[index] for index in inds]
+            types = [storm_modes[index] for index in inds]
+            embs = [storm_embs[index] for index in inds]
+            
+            for region, mode, emb in zip(props, types, embs):
+                # Insert each storm into labels array and merged labels array 
+                # (labels in latter will later be overwritten by collocated deeper storms)
+                coords = region.coords
+                merged_labels[coords[:,0], coords[:,1]] = region.label
+                # based on storm type and embedded status, get integer corresponding to storm mode, 
+                # and insert into storm modes array
+                storm_type_int, storm_type_str = self.get_storm_labels(emb, mode)
+                storm_mode_array[coords[:,0], coords[:,1]] = storm_type_int
+        
+        return storm_mode_array, merged_labels

--- a/monte_python/storm_mode_classifier.py
+++ b/monte_python/storm_mode_classifier.py
@@ -176,7 +176,7 @@ class StormModeClassifier:
         
         dbz_labels, dbz_props = self._label_and_qc(dbz_vals, self._dbz_thresh, self._dbz_qc_params)
         rot_labels, rot_props = self._label_and_qc(rot_vals, self._rot_thresh, self._rot_qc_params)   
-        
+    
         storm_types, labels_with_matched_rotation = get_storm_types(
                         None,
                         dbz_labels,
@@ -187,10 +187,11 @@ class StormModeClassifier:
                         rot_vals,
                         ANALYSIS_DX= self._ANALYSIS_DX
                     )
-                    
+    
         min_thres_vals = np.arange(
                             self._dbz_thresh + 0, self._dbz_thresh + 23.1, 1
                         )
+        
         for itr, min_thres in enumerate(min_thres_vals):
             (
              storm_types,
@@ -215,13 +216,12 @@ class StormModeClassifier:
 
         for n in range(len(dbz_props)):
             dbz_props[n].label = n + 1
-
+    
         storm_modes, merged_labels = self._embedding_to_2d_array( dbz_vals.shape,
                                                                  dbz_props, 
                                                                 storm_types, 
                                                                 storm_depths, 
                                                                 storm_embs)
-
         return storm_modes, merged_labels, dbz_props    
         
     def get_storm_labels(self, storm_emb, storm_type):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ scikit-image>=0.19.0
 pandas
 matplotlib<=3.4.3
 xarray >= 0.21.1
+numba
+numba_kdtree


### PR DESCRIPTION
I pulled out some of the more time-intensive iterative loops and wrapped them in @jit decorators. For files with a lot of objects, this achieved 65-70% time reduction in run time. 

I did a one-to-one comparison of the output 2d fields (mode and labels) and they match that produced by the old code. 